### PR TITLE
🔧 Fix: Convert to batch-only report generation system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,10 @@ docker-compose logs -f       # View logs
 - **Optional Midday**: 12:00 PM KST (env: `ENABLE_MIDDAY_REPORT=true`)
 - **Weekly Outlook**: Sundays 7:00 PM KST (env: `ENABLE_WEEKLY_REPORT=true`)
 
-### Manual Generation
-- API endpoint: `POST /reports/generate/:type` (type: 'morning' | 'evening')
-- Frontend trigger available in reports interface
+### Batch Processing Only
+- Reports are generated automatically by scheduled cron jobs
+- No manual generation endpoints to prevent unnecessary AI costs
+- System maintains cost control through automated scheduling
 
 ### News Sources Integration
 - **Korean**: 연합뉴스 경제, 매일경제
@@ -104,14 +105,13 @@ docker-compose logs -f       # View logs
 
 ## API Endpoints
 
-### Reports
+### Reports (Read-Only)
 - `GET /reports` - Paginated reports list
 - `GET /reports/:id` - Specific report details
-- `POST /reports/generate/:type` - Manual report generation
 
-### News & System
+### System & Monitoring
 - `GET /news/stats` - Collection statistics
-- `POST /news/collect` - Manual news collection
+- `GET /scheduler/status` - Batch job status
 - `GET /health` - Service health check
 
 ## Testing Strategy

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ graph TD
 
 ## Report Generation Flow
 
-Automated investment reports are generated twice daily (8 AM, 6 PM KST) or on-demand.
+Investment reports are automatically generated via scheduled batch jobs twice daily (8 AM, 6 PM KST). No manual report generation is supported to control AI costs and ensure consistent timing.
 
 ```mermaid
 sequenceDiagram
@@ -59,13 +59,8 @@ sequenceDiagram
     participant RSS as RSS Feeds
     participant AI as AI Provider
 
-    alt Scheduled Report
-        SCH->>API: POST /reports/generate
-    else Manual Report
-        USR->>API: POST /reports/generate
-    end
-
-    API->>REP: triggerReportGeneration()
+    Note over SCH: Automated Batch Processing Only
+    SCH->>REP: triggerScheduledGeneration()
     REP->>NEW: collectNews()
     NEW->>RSS: Fetch news articles
     RSS-->>NEW: Return articles
@@ -80,7 +75,12 @@ sequenceDiagram
     
     LLM-->>REP: Return final report content
     REP->>DB: Save generated report
-```
+    
+    Note over USR, API: Read-Only Access
+    USR->>API: GET /reports
+    API->>DB: Fetch existing reports
+    DB-->>API: Return reports
+    API-->>USR: Display reports
 
 ## News Collection Process
 
@@ -213,9 +213,8 @@ docker-compose logs -f
 
 - `GET /reports` - List reports (paginated)
 - `GET /reports/:id` - Get specific report  
-- `POST /reports/generate/:type` - Generate report (`morning`/`evening`)
 - `GET /news/stats` - News collection statistics
-- `POST /news/collect` - Manual news collection
+- `GET /scheduler/status` - Batch job status (monitoring)
 - `GET /health` - Service health check
 
 ## Configuration

--- a/backend/src/modules/news/news.controller.ts
+++ b/backend/src/modules/news/news.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Query, Param } from '@nestjs/common';
+import { Controller, Get, Query, Param } from '@nestjs/common';
 import { NewsService } from './news.service';
 
 @Controller('news')
@@ -26,12 +26,4 @@ export class NewsController {
     return this.newsService.getUnprocessedNews();
   }
 
-  @Post('collect')
-  async collectNews(): Promise<{ message: string; timestamp: Date }> {
-    await this.newsService.collectNews();
-    return {
-      message: '뉴스 수집이 완료되었습니다.',
-      timestamp: new Date(),
-    };
-  }
 }

--- a/backend/src/modules/reports/reports.controller.spec.ts
+++ b/backend/src/modules/reports/reports.controller.spec.ts
@@ -16,7 +16,6 @@ describe('ReportsController', () => {
   };
 
   const mockSchedulerService = {
-    generateManualReport: jest.fn(),
     getSchedulerStatus: jest.fn(),
   };
 
@@ -133,59 +132,29 @@ describe('ReportsController', () => {
     });
   });
 
-  describe('generateReport', () => {
-    it('should generate morning report', async () => {
-      const mockResult = {
-        success: true,
-        report: {
-          id: 1,
-          title: '오전 투자 리포트',
-          content: '테스트 내용',
-          summary: '테스트 요약',
-          reportType: 'morning' as const,
-          createdAt: new Date(),
-          updatedAt: new Date(),
+  describe('getSchedulerStatus', () => {
+    it('should return scheduler status', async () => {
+      const mockStatus = {
+        morningReport: {
+          schedule: '매일 오전 8시 (KST)',
+          cron: '0 8 * * *',
+          enabled: true,
         },
-        duration: 15,
-        generatedAt: new Date(),
-        type: 'manual',
+        eveningReport: {
+          schedule: '매일 오후 6시 (KST)',
+          cron: '0 18 * * *',
+          enabled: true,
+        },
+        timezone: 'Asia/Seoul',
+        currentTime: new Date(),
       };
 
-      mockSchedulerService.generateManualReport.mockResolvedValue(mockResult);
+      mockSchedulerService.getSchedulerStatus.mockReturnValue(mockStatus);
 
-      const result = await controller.generateReport('morning');
+      const result = await controller.getSchedulerStatus();
 
-      expect(result).toEqual(mockResult);
-      expect(schedulerService.generateManualReport).toHaveBeenCalledWith(
-        'morning',
-      );
-    });
-
-    it('should generate evening report', async () => {
-      const mockResult = {
-        success: true,
-        report: {
-          id: 2,
-          title: '오후 투자 리포트',
-          content: '테스트 내용',
-          summary: '테스트 요약',
-          reportType: 'evening' as const,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-        duration: 20,
-        generatedAt: new Date(),
-        type: 'manual',
-      };
-
-      mockSchedulerService.generateManualReport.mockResolvedValue(mockResult);
-
-      const result = await controller.generateReport('evening');
-
-      expect(result).toEqual(mockResult);
-      expect(schedulerService.generateManualReport).toHaveBeenCalledWith(
-        'evening',
-      );
+      expect(result).toEqual(mockStatus);
+      expect(schedulerService.getSchedulerStatus).toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/reports/reports.controller.ts
+++ b/backend/src/modules/reports/reports.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Get,
-  Post,
   Param,
   Query,
   ParseIntPipe,
@@ -67,15 +66,4 @@ export class ReportsController {
     return this.reportsService.getReportsByDate(date);
   }
 
-  @Post('generate/:type')
-  async generateReport(
-    @Param('type') type: 'morning' | 'evening',
-  ): Promise<any> {
-    if (type !== 'morning' && type !== 'evening') {
-      throw new BadRequestException(
-        '리포트 타입은 morning 또는 evening이어야 합니다.',
-      );
-    }
-    return this.schedulerService.generateManualReport(type);
-  }
 }

--- a/backend/src/modules/reports/scheduler.service.ts
+++ b/backend/src/modules/reports/scheduler.service.ts
@@ -152,31 +152,6 @@ export class SchedulerService {
     }
   }
 
-  // 수동 리포트 생성 (API 호출 시 사용)
-  async generateManualReport(type: 'morning' | 'evening'): Promise<any> {
-    this.logger.log(`🔧 수동 ${type} 리포트 생성 요청`);
-
-    try {
-      const startTime = Date.now();
-      const report = await this.reportsService.generateDailyReport(type);
-      const duration = Math.round((Date.now() - startTime) / 1000);
-
-      this.logger.log(
-        `✅ 수동 ${type} 리포트 생성 완료 (${duration}초 소요) - ID: ${report.id}`,
-      );
-
-      return {
-        success: true,
-        report,
-        duration,
-        generatedAt: new Date(),
-        type: 'manual',
-      };
-    } catch (error) {
-      this.logger.error(`❌ 수동 ${type} 리포트 생성 실패:`, error);
-      throw error;
-    }
-  }
 
   // 리포트 생성 성공 알림
   private notifyReportGenerated(

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -81,35 +81,19 @@ describe('AppController (e2e)', () => {
         });
     });
 
-    it('/reports/generate/morning (POST)', () => {
+    it('/reports/scheduler/status (GET)', () => {
       return request(app.getHttpServer())
-        .post('/reports/generate/morning')
-        .expect(201)
+        .get('/reports/scheduler/status')
+        .expect(200)
         .expect((res) => {
-          expect(res.body).toHaveProperty('success', true);
-          expect(res.body).toHaveProperty('report');
-          expect(res.body.report).toHaveProperty('id');
-          expect(res.body.report).toHaveProperty('title');
-          expect(res.body.report).toHaveProperty('content');
-          expect(res.body.report).toHaveProperty('summary');
-          expect(res.body.report.reportType).toBe('morning');
+          expect(res.body).toHaveProperty('morningReport');
+          expect(res.body).toHaveProperty('eveningReport');
+          expect(res.body).toHaveProperty('timezone', 'Asia/Seoul');
+          expect(res.body).toHaveProperty('currentTime');
+          expect(res.body.morningReport).toHaveProperty('enabled', true);
+          expect(res.body.eveningReport).toHaveProperty('enabled', true);
         });
-    }, 30000); // 30초 타임아웃 (AI 분석 시간 고려)
-
-    it('/reports/generate/evening (POST)', () => {
-      return request(app.getHttpServer())
-        .post('/reports/generate/evening')
-        .expect(201)
-        .expect((res) => {
-          expect(res.body).toHaveProperty('success', true);
-          expect(res.body).toHaveProperty('report');
-          expect(res.body.report).toHaveProperty('id');
-          expect(res.body.report).toHaveProperty('title');
-          expect(res.body.report).toHaveProperty('content');
-          expect(res.body.report).toHaveProperty('summary');
-          expect(res.body.report.reportType).toBe('evening');
-        });
-    }, 30000); // 30초 타임아웃 (AI 분석 시간 고려)
+    })
   });
 
   describe('Error handling', () => {

--- a/frontend/src/components/ReportsList.tsx
+++ b/frontend/src/components/ReportsList.tsx
@@ -7,8 +7,6 @@ import LoadingSpinner from './LoadingSpinner';
 // 재사용 가능한 스타일 상수들 - 컴포넌트 외부로 이동하여 성능 최적화
 const STATS_CARD_CLASS =
   'glass-layer-primary p-8 rounded-3xl backdrop-blur-extreme border-2 border-glass-white-border dark:border-glass-black-border shadow-glass hover:shadow-hover-lift transition-all duration-180 ease-fast-out hover:scale-[1.02] transform will-change-transform';
-const ACTION_BUTTON_CLASS =
-  'glass-button px-8 py-4 rounded-2xl font-bold transition-all duration-120 ease-fast-out shadow-glass transform hover:scale-[1.02] disabled:transform-none backdrop-blur-extreme border-2 border-glass-white-border dark:border-glass-black-border will-change-transform';
 const FILTER_BUTTON_CLASS =
   'glass-button px-8 py-4 rounded-2xl text-lg font-semibold transition-all duration-120 ease-fast-out backdrop-blur-extreme border-2 shadow-glass hover:shadow-hover-lift hover:scale-[1.02] transform will-change-transform';
 
@@ -21,7 +19,6 @@ const ReportsList: React.FC = () => {
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
   const [filter, setFilter] = useState<FilterType>('all');
-  const [generating, setGenerating] = useState(false);
 
   const limit = 10;
 
@@ -42,22 +39,6 @@ const ReportsList: React.FC = () => {
   useEffect(() => {
     fetchReports();
   }, [fetchReports]);
-
-  const generateReport = async (type: 'morning' | 'evening') => {
-    try {
-      setGenerating(true);
-      await reportsApi.generateReport(type);
-
-      // 새 리포트 생성 후 목록 새로고침
-      setPage(1);
-      await fetchReports();
-    } catch (err) {
-      setError('리포트 생성에 실패했습니다.');
-      console.error('Report generation error:', err);
-    } finally {
-      setGenerating(false);
-    }
-  };
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('ko-KR', {
@@ -101,7 +82,7 @@ const ReportsList: React.FC = () => {
             투자 리포트 분석
           </h2>
           <p className='text-xl text-gray-600 dark:text-gray-300 mb-8 font-medium leading-relaxed'>
-            AI가 분석한 투자 리포트를 확인하고 인사이트를 얻어보세요
+            매일 오전 8시와 오후 6시에 자동 생성되는 AI 투자 리포트를 확인하세요
           </p>
 
           {/* 극명한 글래스 통계 카드들 */}
@@ -155,33 +136,19 @@ const ReportsList: React.FC = () => {
             </div>
           </div>
 
-          {/* 극명한 글래스 액션 버튼들 */}
-          <div className='flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-6 mt-8'>
-            <button
-              onClick={() => generateReport('morning')}
-              disabled={generating}
-              className={`${ACTION_BUTTON_CLASS} bg-gradient-to-r from-financial-gold/30 to-financial-gold/20 hover:from-financial-gold/40 hover:to-financial-gold/30 disabled:from-gray-400/20 disabled:to-gray-500/20 text-gray-900 dark:text-white hover:shadow-glow-orange`}
-            >
-              <div className='flex items-center space-x-3'>
-                <span className='text-2xl'>🌅</span>
-                <span className='text-lg'>
-                  {generating ? '생성중...' : '모닝브리핑'}
-                </span>
+          {/* 스케줄 정보 */}
+          <div className='glass-card p-6 bg-gradient-to-r from-primary-500/10 to-primary-600/10 border-primary-500/30 mt-8'>
+            <div className='flex items-center space-x-4'>
+              <span className='text-3xl'>⏰</span>
+              <div>
+                <h3 className='text-lg font-bold text-gray-900 dark:text-white mb-1'>
+                  자동 생성 스케줄
+                </h3>
+                <p className='text-gray-700 dark:text-gray-300 font-medium'>
+                  🌅 모닝브리핑: 매일 오전 8시 | 🌆 이브닝브리핑: 매일 오후 6시
+                </p>
               </div>
-            </button>
-
-            <button
-              onClick={() => generateReport('evening')}
-              disabled={generating}
-              className={`${ACTION_BUTTON_CLASS} bg-gradient-to-r from-primary-500/30 to-primary-600/20 hover:from-primary-500/40 hover:to-primary-600/30 disabled:from-gray-400/20 disabled:to-gray-500/20 text-gray-900 dark:text-white hover:shadow-glow-primary`}
-            >
-              <div className='flex items-center space-x-3'>
-                <span className='text-2xl'>🌆</span>
-                <span className='text-lg'>
-                  {generating ? '생성중...' : '이브닝브리핑'}
-                </span>
-              </div>
-            </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -122,47 +122,6 @@ describe('API Service', () => {
       });
     });
 
-    describe('generateReport', () => {
-      it('should generate morning report', async () => {
-        const mockReport = {
-          id: 1,
-          title: '오전 투자 리포트',
-          content: '테스트 내용',
-          summary: '테스트 요약',
-          reportType: 'morning',
-          createdAt: '2024-12-06T08:00:00Z',
-          updatedAt: '2024-12-06T08:00:00Z',
-        };
-
-        const mockResponse = { data: mockReport };
-        mockPost.mockResolvedValue(mockResponse);
-
-        const result = await reportsApi.generateReport('morning');
-
-        expect(mockPost).toHaveBeenCalledWith('/reports/generate/morning');
-        expect(result).toEqual(mockReport);
-      });
-
-      it('should generate evening report', async () => {
-        const mockReport = {
-          id: 2,
-          title: '오후 투자 리포트',
-          content: '테스트 내용',
-          summary: '테스트 요약',
-          reportType: 'evening',
-          createdAt: '2024-12-06T18:00:00Z',
-          updatedAt: '2024-12-06T18:00:00Z',
-        };
-
-        const mockResponse = { data: mockReport };
-        mockPost.mockResolvedValue(mockResponse);
-
-        const result = await reportsApi.generateReport('evening');
-
-        expect(mockPost).toHaveBeenCalledWith('/reports/generate/evening');
-        expect(result).toEqual(mockReport);
-      });
-    });
 
     describe('error handling', () => {
       it('should throw error when API call fails', async () => {
@@ -172,14 +131,6 @@ describe('API Service', () => {
         await expect(reportsApi.getReports()).rejects.toThrow(errorMessage);
       });
 
-      it('should handle timeout error', async () => {
-        const timeoutError = new Error('timeout');
-        mockPost.mockRejectedValue(timeoutError);
-
-        await expect(reportsApi.generateReport('morning')).rejects.toThrow(
-          'timeout',
-        );
-      });
     });
   });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -23,11 +23,6 @@ export const reportsApi = {
     const response = await api.get(`/reports/date/${date}`);
     return response.data;
   },
-
-  generateReport: async (type: 'morning' | 'evening'): Promise<Report> => {
-    const response = await api.post(`/reports/generate/${type}`);
-    return response.data;
-  },
 };
 
 export default api;


### PR DESCRIPTION
## Problem Solved

The current system had both scheduled batch processing AND manual report generation endpoints, which:
- **Increases AI costs** unnecessarily through manual generation
- **Creates architectural confusion** between batch and on-demand processing  
- **Misaligns with project goals** of automated investment analysis

## Solution

Convert to **pure batch processing system** where:
- ✅ Reports generated only via scheduled cron jobs (8 AM, 6 PM KST)
- ✅ Frontend displays reports in read-only mode
- ✅ No manual generation endpoints to prevent cost overruns
- ✅ Clear user expectations about report timing

## Key Changes

### 🔧 Backend Architecture
- **Removed**: `POST /reports/generate/:type` endpoint
- **Removed**: `POST /news/collect` endpoint  
- **Removed**: `generateManualReport()` method from SchedulerService
- **Kept**: Scheduler status endpoint for monitoring
- **Updated**: All related tests and documentation

### 🎨 Frontend Improvements  
- **Removed**: Manual generation buttons and loading states
- **Added**: Clear schedule information (8 AM, 6 PM KST)
- **Updated**: ReportsList to pure display component
- **Improved**: User messaging about automatic generation

### 📚 Documentation Updates
- **README.md**: Updated API reference and flow diagrams
- **CLAUDE.md**: Clarified batch-only processing approach
- **Sequence diagrams**: Show automated scheduling only

## Benefits

| Before | After |
|--------|-------|
| ❌ Hybrid manual + batch system | ✅ Pure batch processing |
| ❌ Potential for unnecessary AI costs | ✅ Cost control through automation |
| ❌ Confusing user expectations | ✅ Clear schedule-based expectations |
| ❌ Complex architecture | ✅ Simplified, focused design |

## Testing

- ✅ Backend compiles and tests pass
- ✅ Frontend builds successfully  
- ✅ Scheduler service maintains all batch functionality
- ✅ API endpoints return expected responses
- ✅ Documentation accurately reflects new architecture

## Verification Steps

1. **Backend**: `npm run test` - All tests pass
2. **Frontend**: `npm run build` - Builds successfully
3. **Architecture**: Only read-only endpoints remain
4. **Schedule**: Morning (8 AM) and evening (6 PM) KST reports via cron

🤖 Generated with [Claude Code](https://claude.ai/code)