### PR TITLE
[codex] Fix P0 env and universe alignment

### DIFF
--- a/backend/src/data-source.spec.ts
+++ b/backend/src/data-source.spec.ts
@@ -1,0 +1,38 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('data-source env loading', () => {
+  const originalEnv = { ...process.env };
+  let tempDir: string;
+
+  beforeEach(() => {
+    jest.resetModules();
+    tempDir = mkdtempSync(join(tmpdir(), 'lincei-data-source-env-'));
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('loads repo env aliases before CLI runtime services inspect credentials', async () => {
+    const envPath = join(tempDir, '.env');
+    writeFileSync(
+      envPath,
+      [
+        'QUANTCONNECT_USER_ID=test-user',
+        'QUANTCONNECT_API_TOKEN=test-token',
+        'OPENAI_API_KEY=test-openai-key',
+      ].join('\n'),
+    );
+    process.env.LINCEI_ENV_FILE = envPath;
+
+    await import('./data-source');
+
+    expect(process.env.QUANTCONNECT_USER_ID).toBe('test-user');
+    expect(process.env.QUANTCONNECT_API_TOKEN).toBe('test-token');
+    expect(process.env.OPENAI_API_KEY).toBe('test-openai-key');
+  });
+});

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
-import { config } from 'dotenv';
 import { AutonomousRun } from './entities/autonomous-run.entity';
 import { AutonomousRunSchedule } from './entities/autonomous-run-schedule.entity';
 import { BrokerFill } from './entities/broker-fill.entity';
@@ -45,8 +44,9 @@ import { ResearchJobRecord } from './entities/research-job-record.entity';
 import { AddSpecEvidenceTables1764288000000 } from './migrations/1764288000000-AddSpecEvidenceTables';
 import { AddLiveShadowEvidenceMode1764374400000 } from './migrations/1764374400000-AddLiveShadowEvidenceMode';
 import { AddResearchFactoryTables1764460800000 } from './migrations/1764460800000-AddResearchFactoryTables';
+import { loadRepoEnv } from './shared/repo-env.loader';
 
-config();
+loadRepoEnv();
 
 export const databaseEntities = [
   Report,

--- a/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts
+++ b/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts
@@ -6,6 +6,16 @@ import { CapitalEvidenceSliceService } from './capital-evidence-slice.service';
 import { ResearchFactoryService } from './research-factory.service';
 
 describe('CapitalEvidenceSliceService', () => {
+  const originalUniverseSymbols = process.env.V1_UNIVERSE_SYMBOLS;
+
+  afterEach(() => {
+    if (originalUniverseSymbols === undefined) {
+      delete process.env.V1_UNIVERSE_SYMBOLS;
+    } else {
+      process.env.V1_UNIVERSE_SYMBOLS = originalUniverseSymbols;
+    }
+  });
+
   it('records retained blocked variants and promotion status when prerequisites are missing', async () => {
     const savedJobs: ResearchJobRecord[] = [];
     const service = new CapitalEvidenceSliceService(
@@ -36,6 +46,31 @@ describe('CapitalEvidenceSliceService', () => {
     expect(savedJobs.every((job) => job.jobType === 'ablation')).toBe(true);
     expect(result.brokerWriteCandidateStatus.status).toBe('blocked');
     expect(JSON.stringify(result.promotionDecision)).toContain('blocked');
+    expect(result.universe).toContain('SMH');
+  });
+
+  it('runs and reports the same explicit universe override', async () => {
+    const orchestrator = mockOrchestrator();
+    const service = new CapitalEvidenceSliceService(
+      orchestrator,
+      mockResearchFactory(),
+      {
+        create: (record: ResearchJobRecord) => record,
+        save: async (record: ResearchJobRecord) => record,
+      } as unknown as Repository<ResearchJobRecord>,
+      {
+        find: async () => [],
+      } as unknown as Repository<AlphaDecision>,
+    );
+
+    const result = await service.run({
+      universe: ['SPY', 'QQQ'],
+      maxBacktestWorkers: 1,
+    });
+
+    expect(result.universe).toEqual(['SPY', 'QQQ']);
+    expect(orchestrator.prepareLeanLocalData).toHaveBeenCalled();
+    expect(process.env.V1_UNIVERSE_SYMBOLS).toBe(originalUniverseSymbols);
   });
 });
 

--- a/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.ts
+++ b/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.ts
@@ -13,12 +13,11 @@ import {
 } from '../../../entities/research-job-record.entity';
 import { hashObject } from '../../../shared/hash.util';
 import { V1PilotOrchestratorService } from '../v1-pilot-orchestrator.service';
+import { resolveUniverseSelection } from '../universe/universe-manifest';
 import { ResearchFactoryService } from './research-factory.service';
 
 export const DEFAULT_CAPITAL_HYPOTHESIS_ID =
   'research-hypothesis-alphaarchitect-08-rethinking-trend-following-optimal-regime-dependent-allocation';
-
-export const DEFAULT_CAPITAL_UNIVERSE = ['SPY', 'QQQ', 'TLT', 'IEF'] as const;
 
 export const DEFAULT_CAPITAL_VARIANTS = [
   {
@@ -114,12 +113,19 @@ export class CapitalEvidenceSliceService {
   async run(
     options: CapitalEvidenceRunOptions = {},
   ): Promise<CapitalEvidenceSliceResult> {
+    return this.withUniverseOverride(options.universe, async () =>
+      this.runWithResolvedUniverse(options),
+    );
+  }
+
+  private async runWithResolvedUniverse(
+    options: CapitalEvidenceRunOptions,
+  ): Promise<CapitalEvidenceSliceResult> {
     const startedAt = new Date();
     const runId = this.runId(startedAt, options);
     const hypothesisId = options.hypothesisId ?? DEFAULT_CAPITAL_HYPOTHESIS_ID;
-    const universe = options.universe?.length
-      ? options.universe
-      : [...DEFAULT_CAPITAL_UNIVERSE];
+    const universeSelection = resolveUniverseSelection();
+    const universe = universeSelection.activeSymbols;
     const maxBacktestWorkers = options.maxBacktestWorkers ?? 1;
     const steps: CapitalEvidenceStep[] = [];
     const blockers: string[] = [];
@@ -275,6 +281,31 @@ export class CapitalEvidenceSliceService {
       },
       researchStatus,
     };
+  }
+
+  private async withUniverseOverride<T>(
+    universe: string[] | undefined,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    if (!universe?.length) {
+      return fn();
+    }
+
+    const previousUniverseSymbols = process.env.V1_UNIVERSE_SYMBOLS;
+    process.env.V1_UNIVERSE_SYMBOLS = universe
+      .map((symbol) => symbol.trim().toUpperCase())
+      .filter(Boolean)
+      .join(',');
+
+    try {
+      return await fn();
+    } finally {
+      if (previousUniverseSymbols === undefined) {
+        delete process.env.V1_UNIVERSE_SYMBOLS;
+      } else {
+        process.env.V1_UNIVERSE_SYMBOLS = previousUniverseSymbols;
+      }
+    }
   }
 
   private async recordVariantOutcomes(input: {


### PR DESCRIPTION
## Summary
- Fix repo env loading so CLI/runtime imports use the canonical repo-root `.env` instead of masked empty backend env values.
- Align `capital run` reported universe with the universe actually used by data preparation and alpha generation.
- Add focused tests for env alias loading and universe override restoration.

## Result
- `qc list-projects` now reaches QuantConnect with configured credentials instead of reporting missing credentials.
- `capital run --universe SPY,QQQ` now reports and prepares only `SPY,QQQ`; the remaining blocker is market/alpha evidence, not universe mismatch.

## Validation
- `cd backend && bun run test -- src/data-source.spec.ts src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts src/runtime/create-lincei-runtime.spec.ts`
- `cd backend && bun run build`
- `git diff --check`
- `bun --cwd=backend run lincei -- qc list-projects --limit 1 --json`
- `bun --cwd=backend run lincei -- capital run --universe SPY,QQQ --semantic-limit 1 --max-backtest-workers 1 --json` exited 2 with expected data/alpha blockers
