### PR TITLE
Fix capital evidence replay and Cloud targets

### DIFF
--- a/backend/src/modules/v1-pilot/alpha/feature-snapshot.service.ts
+++ b/backend/src/modules/v1-pilot/alpha/feature-snapshot.service.ts
@@ -63,8 +63,9 @@ export class FeatureSnapshotService {
       };
       validateFeatureSnapshot(snapshot);
       snapshots.push(snapshot);
-      await this.featureRepository.save(
+      await this.featureRepository.upsert(
         this.featureRepository.create(snapshot),
+        ['id'],
       );
     }
 

--- a/backend/src/modules/v1-pilot/alpha/llm-alpha.service.ts
+++ b/backend/src/modules/v1-pilot/alpha/llm-alpha.service.ts
@@ -134,9 +134,7 @@ export class LlmAlphaService {
     });
 
     if (decisions.length > 0) {
-      await this.alphaRepository.save(
-        decisions.map((decision) => this.alphaRepository.create(decision)),
-      );
+      await this.saveDecisions(decisions);
     }
 
     return decisions;
@@ -214,12 +212,19 @@ export class LlmAlphaService {
     }
 
     if (decisions.length > 0) {
-      await this.alphaRepository.save(
-        decisions.map((decision) => this.alphaRepository.create(decision)),
-      );
+      await this.saveDecisions(decisions);
     }
 
     return decisions;
+  }
+
+  private async saveDecisions(
+    decisions: AlphaDecisionContract[],
+  ): Promise<void> {
+    await this.alphaRepository.upsert(
+      decisions.map((decision) => this.alphaRepository.create(decision)),
+      ['id'],
+    );
   }
 
   private buildPrompt(

--- a/backend/src/modules/v1-pilot/alpha/llm-event-feature.service.ts
+++ b/backend/src/modules/v1-pilot/alpha/llm-event-feature.service.ts
@@ -269,10 +269,11 @@ export class LlmEventFeatureService {
     if (features.length === 0) {
       return [];
     }
-    const saved = await this.featureRepository.save(
+    await this.featureRepository.upsert(
       features.map((feature) => this.featureRepository.create(feature)),
+      ['id'],
     );
-    return saved.map((feature) => ({ ...feature }));
+    return features;
   }
 
   private exportLatestFeatures(features: LlmEventFeatureContract[]): void {

--- a/backend/src/modules/v1-pilot/alpha/meta-alpha.service.ts
+++ b/backend/src/modules/v1-pilot/alpha/meta-alpha.service.ts
@@ -35,8 +35,6 @@ export class MetaAlphaService {
     const metaDecisions: AlphaDecisionContract[] = [];
     const exportRecords: MetaDecisionExportRecord[] = [];
 
-    const savePromises: Promise<AlphaDecision>[] = [];
-
     snapshots.forEach((snapshot) => {
       const numericDecision = numeric.find(
         (item) => item.symbol === snapshot.symbol,
@@ -167,12 +165,14 @@ export class MetaAlphaService {
         numericFeatureRefs: decision.numericFeatureRefs ?? [],
         outputHash: decision.outputHash,
       });
-      savePromises.push(
-        this.alphaRepository.save(this.alphaRepository.create(decision)),
-      );
     });
 
-    await Promise.all(savePromises);
+    if (metaDecisions.length > 0) {
+      await this.alphaRepository.upsert(
+        metaDecisions.map((decision) => this.alphaRepository.create(decision)),
+        ['id'],
+      );
+    }
     this.exportMetaDecisionsFile(exportRecords);
     return metaDecisions;
   }

--- a/backend/src/modules/v1-pilot/alpha/numeric-alpha.service.ts
+++ b/backend/src/modules/v1-pilot/alpha/numeric-alpha.service.ts
@@ -90,9 +90,7 @@ export class NumericAlphaService {
     });
 
     if (decisions.length > 0) {
-      await this.alphaRepository.save(
-        decisions.map((decision) => this.alphaRepository.create(decision)),
-      );
+      await this.saveDecisions(decisions);
     }
 
     return decisions.sort((left, right) => right.confidence - left.confidence);
@@ -139,12 +137,19 @@ export class NumericAlphaService {
     });
 
     if (decisions.length > 0) {
-      await this.alphaRepository.save(
-        decisions.map((decision) => this.alphaRepository.create(decision)),
-      );
+      await this.saveDecisions(decisions);
     }
 
     return decisions;
+  }
+
+  private async saveDecisions(
+    decisions: AlphaDecisionContract[],
+  ): Promise<void> {
+    await this.alphaRepository.upsert(
+      decisions.map((decision) => this.alphaRepository.create(decision)),
+      ['id'],
+    );
   }
 
   private buildDecision(input: {

--- a/backend/src/modules/v1-pilot/lean/lean-cloud-artifact-mapper.spec.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-cloud-artifact-mapper.spec.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { QuantConnectCloudArtifactMapper } from './lean-cloud-artifact-mapper';
+
+describe('QuantConnectCloudArtifactMapper', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'lean-cloud-artifact-mapper-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('derives net target weights from signed filled quantities', () => {
+    const mapper = new QuantConnectCloudArtifactMapper();
+
+    mapper.writeImportedArtifacts(
+      {
+        resultDirectory: tempDir,
+        runId: 'qc-import-test',
+        cloudBacktestId: 'cloud-backtest-id',
+        projectId: 32097697,
+        completedAt: new Date('2026-05-29T00:00:00Z'),
+      },
+      {
+        backtest: {
+          status: 'Completed.',
+          backtestStart: '2024-01-01T00:00:00Z',
+          backtestEnd: '2024-01-31T00:00:00Z',
+          statistics: { 'End Equity': '100000' },
+        },
+        insights: [
+          {
+            id: 'i-nvda',
+            symbol: 'NVDA RHM8UTD8DT2D',
+            direction: 0,
+            period: 1814400,
+            generatedTime: 1711569600,
+          },
+        ],
+        orders: [
+          {
+            id: 'buy-nvda',
+            symbol: 'NVDA RHM8UTD8DT2D',
+            events: [
+              {
+                id: 'buy-nvda-fill',
+                status: 3,
+                direction: 0,
+                fillQuantity: 10,
+                fillPrice: 100,
+                utcTime: 1711656000,
+              },
+            ],
+          },
+          {
+            id: 'sell-nvda',
+            symbol: 'NVDA RHM8UTD8DT2D',
+            events: [
+              {
+                id: 'sell-nvda-fill',
+                status: 3,
+                direction: 1,
+                fillQuantity: -4,
+                fillPrice: 100,
+                utcTime: 1711742400,
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    const targets = JSON.parse(
+      readFileSync(join(tempDir, 'portfolio_targets.json'), 'utf8'),
+    ) as {
+      targets: { symbol: string; targetWeight: number }[];
+      grossExposurePct: number;
+      maxSingleNamePct: number;
+    };
+    const insights = JSON.parse(
+      readFileSync(join(tempDir, 'insights.json'), 'utf8'),
+    ) as {
+      insights: { symbol: string; periodDays: number; generatedTime: string }[];
+    };
+    const events = JSON.parse(
+      readFileSync(join(tempDir, 'order_events.json'), 'utf8'),
+    ) as {
+      events: { symbol: string; utcTime: string }[];
+    };
+
+    expect(targets.targets).toEqual([
+      expect.objectContaining({ symbol: 'NVDA', targetWeight: 0.006 }),
+    ]);
+    expect(targets.grossExposurePct).toBe(0.006);
+    expect(targets.maxSingleNamePct).toBe(0.006);
+    expect(insights.insights[0]).toMatchObject({
+      symbol: 'NVDA',
+      periodDays: 21,
+      generatedTime: '2024-03-27T20:00:00.000Z',
+    });
+    expect(events.events[0]).toMatchObject({
+      symbol: 'NVDA',
+      utcTime: '2024-03-28T20:00:00.000Z',
+    });
+  });
+});

--- a/backend/src/modules/v1-pilot/lean/lean-cloud-artifact-mapper.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-cloud-artifact-mapper.ts
@@ -34,6 +34,9 @@ type NormalizedCloudOrderEvent = {
   utcTime: string;
 };
 
+const SECONDS_PER_DAY = 86_400;
+const QUANTCONNECT_SYMBOL_ID_PATTERN = /^[A-Z0-9]{8,}$/;
+
 export type QuantConnectCloudArtifactPayload = {
   backtest: QuantConnectBacktestPayload;
   insights: Record<string, unknown>[];
@@ -98,7 +101,7 @@ export class QuantConnectCloudArtifactMapper {
         input.completedAt.toISOString(),
       targets: derivedTargets,
       ...this.targetExposure(derivedTargets),
-      riskNotes: ['derived_from_quantconnect_cloud_orders'],
+      riskNotes: ['derived_from_quantconnect_cloud_net_fill_notional'],
     });
     this.writeJson(join(input.resultDirectory, 'data-monitor-report.json'), {
       'total-data-requests-count': 1,
@@ -115,18 +118,17 @@ export class QuantConnectCloudArtifactMapper {
     index: number,
   ): NormalizedCloudInsight {
     const symbol = this.symbolValue(insight.symbol) || 'UNKNOWN';
-    const generatedTime =
-      String(
-        insight.generatedTimeUtc ??
-          insight.generatedTime ??
-          insight.closeTimeUtc ??
-          new Date().toISOString(),
-      ) || new Date().toISOString();
+    const generatedTime = this.timestampValue(
+      insight.generatedTimeUtc ??
+        insight.generatedTime ??
+        insight.closeTimeUtc ??
+        new Date().toISOString(),
+    );
     return {
       id: String(insight.id ?? `cloud-insight-${index}-${symbol}`),
       symbol,
       direction: this.directionName(insight.direction),
-      periodDays: Number(insight.periodDays ?? insight.period ?? 1) || 1,
+      periodDays: this.periodDaysValue(insight.periodDays ?? insight.period),
       confidence: Number(insight.confidence ?? 0.5) || 0.5,
       magnitude: Number(insight.magnitude ?? 0) || 0,
       sourceModel: String(insight.sourceModel ?? 'quantconnect-cloud'),
@@ -175,7 +177,7 @@ export class QuantConnectCloudArtifactMapper {
       fillQuantity: Number.isFinite(fillQuantity) ? fillQuantity : 0,
       fillPrice: Number.isFinite(fillPrice) ? fillPrice : 0,
       orderFee: this.orderFeeValue(event.orderFee),
-      utcTime: String(
+      utcTime: this.timestampValue(
         event.utcTime ??
           event.time ??
           order.lastFillTime ??
@@ -203,10 +205,7 @@ export class QuantConnectCloudArtifactMapper {
       if (!event.status.toLowerCase().includes('filled')) {
         continue;
       }
-      const signedNotional =
-        event.fillQuantity *
-        event.fillPrice *
-        (event.direction === 'sell' ? -1 : 1);
+      const signedNotional = this.signedFillQuantity(event) * event.fillPrice;
       notionalBySymbol.set(
         event.symbol,
         (notionalBySymbol.get(event.symbol) ?? 0) + signedNotional,
@@ -214,13 +213,24 @@ export class QuantConnectCloudArtifactMapper {
     }
     return [...notionalBySymbol.entries()]
       .filter(([symbol]) => (insightsBySymbol.get(symbol) ?? []).length > 0)
+      .filter(([, notional]) => Math.abs(notional / endEquity) > 0.00001)
       .map(([symbol, notional]) => ({
         symbol,
         targetWeight: Number((notional / endEquity).toFixed(6)),
         sourceInsightIds: insightsBySymbol.get(symbol) ?? [],
         riskAdjusted: true,
-        riskNotes: ['derived_from_quantconnect_cloud_orders'],
+        riskNotes: ['derived_from_quantconnect_cloud_net_fill_notional'],
       }));
+  }
+
+  private signedFillQuantity(event: NormalizedCloudOrderEvent): number {
+    if (event.fillQuantity < 0) {
+      return event.fillQuantity;
+    }
+    if (event.direction === 'sell') {
+      return -Math.abs(event.fillQuantity);
+    }
+    return event.fillQuantity;
   }
 
   private targetExposure(targets: { targetWeight: number }[]): {
@@ -241,13 +251,26 @@ export class QuantConnectCloudArtifactMapper {
       return '';
     }
     if (typeof value === 'string') {
-      return value;
+      return this.normalizeSymbol(value);
     }
     if (typeof value === 'object') {
       const candidate = value as { value?: unknown; Value?: unknown };
-      return String(candidate.value ?? candidate.Value ?? '');
+      return this.normalizeSymbol(
+        String(candidate.value ?? candidate.Value ?? ''),
+      );
     }
-    return String(value);
+    return this.normalizeSymbol(String(value));
+  }
+
+  private normalizeSymbol(symbol: string): string {
+    const tokens = symbol.trim().split(/\s+/);
+    if (
+      tokens.length === 2 &&
+      QUANTCONNECT_SYMBOL_ID_PATTERN.test(tokens[1] ?? '')
+    ) {
+      return tokens[0] ?? symbol.trim();
+    }
+    return symbol.trim();
   }
 
   private orderStatusName(value: unknown): string {
@@ -307,6 +330,31 @@ export class QuantConnectCloudArtifactMapper {
     }
     const parsed = Number(value.replace(/[%$,]/g, ''));
     return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  private periodDaysValue(value: unknown): number {
+    const raw = Number(value ?? 1);
+    if (!Number.isFinite(raw) || raw <= 0) {
+      return 1;
+    }
+    return Number((raw > 365 ? raw / SECONDS_PER_DAY : raw).toFixed(6));
+  }
+
+  private timestampValue(value: unknown): string {
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    const raw = String(value ?? '').trim();
+    const numeric = Number(raw);
+    if (Number.isFinite(numeric) && raw !== '') {
+      const milliseconds = numeric < 10_000_000_000 ? numeric * 1000 : numeric;
+      return new Date(milliseconds).toISOString();
+    }
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+    return new Date().toISOString();
   }
 
   private writeJson(path: string, payload: unknown): void {

--- a/backend/src/modules/v1-pilot/lean/lean-cloud-manual-importer.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-cloud-manual-importer.ts
@@ -4,10 +4,12 @@ import { mkdirSync, readFileSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { Repository } from 'typeorm';
 import { LeanRun } from '../../../entities/lean-run.entity';
+import { PortfolioTargetSnapshot } from '../../../entities/portfolio-target-snapshot.entity';
 import { hashObject } from '../../../shared/hash.util';
 import { LeanCloudArtifactWriter } from './lean-cloud-artifact-writer';
 import { QuantConnectCloudRestImporter } from './lean-cloud-rest-importer';
 import { assessLeanRunArtifacts } from './lean-run-acceptance';
+import { importPortfolioTargetSnapshot } from './lean-portfolio-target-importer';
 import {
   leanRuntimeUniverseManifestParameter,
   prepareLeanRuntimeUniverseManifest,
@@ -31,6 +33,8 @@ export class LeanCloudManualImporter {
   constructor(
     @InjectRepository(LeanRun)
     private readonly leanRunRepository: Repository<LeanRun>,
+    @InjectRepository(PortfolioTargetSnapshot)
+    private readonly targetRepository: Repository<PortfolioTargetSnapshot>,
   ) {}
 
   async listCloudProjects(options: { limit?: number } = {}) {
@@ -58,7 +62,18 @@ export class LeanCloudManualImporter {
       where: { importIdempotencyKey: importKey },
     });
     if (existing?.status === 'passed') {
-      return existing;
+      const existingAcceptance = assessLeanRunArtifacts(
+        existing.resultDirectory,
+        'strategy-backtest',
+      );
+      if (existingAcceptance.passed) {
+        await importPortfolioTargetSnapshot(
+          this.targetRepository,
+          existing.runId,
+          existing.portfolioTargetsRef,
+        );
+        return existing;
+      }
     }
 
     const runId = `qc-import-${request.backtestId.slice(0, 12)}`;
@@ -155,7 +170,7 @@ export class LeanCloudManualImporter {
       }
     }
 
-    return this.leanRunRepository.save(
+    const saved = await this.leanRunRepository.save(
       this.leanRunRepository.create({
         runId,
         runtime: 'quantconnect-cloud',
@@ -191,6 +206,12 @@ export class LeanCloudManualImporter {
         importIdempotencyKey: importKey,
       }),
     );
+    await importPortfolioTargetSnapshot(
+      this.targetRepository,
+      saved.runId,
+      saved.portfolioTargetsRef,
+    );
+    return saved;
   }
 
   private writeCloudArtifacts(input: {

--- a/backend/src/modules/v1-pilot/lean/lean-cloud.runner.spec.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-cloud.runner.spec.ts
@@ -2,7 +2,7 @@ import { LeanCloudRunner } from './lean-cloud.runner';
 
 describe('LeanCloudRunner', () => {
   it('classifies_missing_cloud_project_as_blocked', () => {
-    const runner = new LeanCloudRunner({} as any, {} as any);
+    const runner = new LeanCloudRunner({} as any, {} as any, {} as any);
 
     const blockers = (runner as any).classifyBlockers(
       'No project with the given name or id found. Please use --push.',
@@ -14,7 +14,7 @@ describe('LeanCloudRunner', () => {
   });
 
   it('classifies_paid_account_cli_api_requirement_as_blocked', () => {
-    const runner = new LeanCloudRunner({} as any, {} as any);
+    const runner = new LeanCloudRunner({} as any, {} as any, {} as any);
 
     const blockers = (runner as any).classifyBlockers(
       'Error: Please upgrade to paid account to use the API and other local features.',
@@ -26,7 +26,7 @@ describe('LeanCloudRunner', () => {
   });
 
   it('does not treat organization ids as backtest ids', () => {
-    const runner = new LeanCloudRunner({} as any, {} as any);
+    const runner = new LeanCloudRunner({} as any, {} as any, {} as any);
 
     const backtestId = (runner as any).extractBacktestId(
       "Successfully created cloud project 'aggressive_llm_momentum' in organization 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'",
@@ -36,7 +36,7 @@ describe('LeanCloudRunner', () => {
   });
 
   it('classifies_cloud_push_character_rejections_as_blocked', () => {
-    const runner = new LeanCloudRunner({} as any, {} as any);
+    const runner = new LeanCloudRunner({} as any, {} as any, {} as any);
 
     const blockers = (runner as any).classifyBlockers(
       "Cannot push 'aggressive_llm_momentum': Invalid character '+' found in input string at position 62.",
@@ -48,7 +48,7 @@ describe('LeanCloudRunner', () => {
   });
 
   it('does not classify compiler API naming warnings as dataset access blockers', () => {
-    const runner = new LeanCloudRunner({} as any, {} as any);
+    const runner = new LeanCloudRunner({} as any, {} as any, {} as any);
 
     const blockers = (runner as any).classifyBlockers(
       'Warning main.py Line: 59 Column: 45 - "DataNormalizationMode" has no attribute "Adjusted".',

--- a/backend/src/modules/v1-pilot/lean/lean-cloud.runner.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-cloud.runner.ts
@@ -6,6 +6,7 @@ import { join, resolve } from 'path';
 import { randomBytes } from 'crypto';
 import { Repository } from 'typeorm';
 import { LeanRun } from '../../../entities/lean-run.entity';
+import { PortfolioTargetSnapshot } from '../../../entities/portfolio-target-snapshot.entity';
 import { hashObject } from '../../../shared/hash.util';
 import { LeanCliRunner } from './lean-cli.runner';
 import { assessLeanRunArtifacts } from './lean-run-acceptance';
@@ -17,6 +18,7 @@ import {
   resolveUniverseSelection,
   writeUniverseSelectionReport,
 } from '../universe/universe-manifest';
+import { importPortfolioTargetSnapshot } from './lean-portfolio-target-importer';
 
 export type LeanCloudBacktestRequest = {
   projectName?: string;
@@ -35,6 +37,8 @@ export class LeanCloudRunner {
     private readonly leanCliRunner: LeanCliRunner,
     @InjectRepository(LeanRun)
     private readonly leanRunRepository: Repository<LeanRun>,
+    @InjectRepository(PortfolioTargetSnapshot)
+    private readonly targetRepository: Repository<PortfolioTargetSnapshot>,
   ) {}
 
   async runCloudBacktest(
@@ -176,10 +180,15 @@ export class LeanCloudRunner {
       where: { importIdempotencyKey: `cloud:${runId}` },
     });
     if (existing) {
+      await importPortfolioTargetSnapshot(
+        this.targetRepository,
+        existing.runId,
+        existing.portfolioTargetsRef,
+      );
       return existing;
     }
 
-    return this.leanRunRepository.save(
+    const saved = await this.leanRunRepository.save(
       this.leanRunRepository.create({
         runId,
         runtime: 'quantconnect-cloud',
@@ -212,6 +221,12 @@ export class LeanCloudRunner {
         importIdempotencyKey: `cloud:${runId}`,
       }),
     );
+    await importPortfolioTargetSnapshot(
+      this.targetRepository,
+      saved.runId,
+      saved.portfolioTargetsRef,
+    );
+    return saved;
   }
 
   async syncObjectStore(

--- a/backend/src/modules/v1-pilot/lean/lean-portfolio-target-importer.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-portfolio-target-importer.ts
@@ -1,0 +1,30 @@
+import { existsSync, readFileSync } from 'fs';
+import { Repository } from 'typeorm';
+import { PortfolioTargetSnapshot } from '../../../entities/portfolio-target-snapshot.entity';
+import { hashObject } from '../../../shared/hash.util';
+import { LeanPortfolioTargetsPayload } from './lean-run.types';
+
+export async function importPortfolioTargetSnapshot(
+  targetRepository: Repository<PortfolioTargetSnapshot>,
+  leanRunId: string,
+  portfolioTargetsRef?: string,
+): Promise<PortfolioTargetSnapshot | null> {
+  if (!portfolioTargetsRef || !existsSync(portfolioTargetsRef)) {
+    return null;
+  }
+
+  const payload = JSON.parse(
+    readFileSync(portfolioTargetsRef, 'utf8'),
+  ) as LeanPortfolioTargetsPayload;
+  const record = targetRepository.create({
+    id: payload.id,
+    leanRunId: payload.leanRunId ?? leanRunId,
+    asOf: payload.asOf,
+    targets: payload.targets,
+    grossExposurePct: payload.grossExposurePct,
+    maxSingleNamePct: payload.maxSingleNamePct,
+    targetHash: payload.targetHash ?? hashObject(payload),
+  });
+  await targetRepository.upsert(record, ['id']);
+  return record;
+}

--- a/backend/src/modules/v1-pilot/lean/lean-run-acceptance.spec.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-run-acceptance.spec.ts
@@ -176,7 +176,49 @@ describe('lean run acceptance', () => {
 
     const report = assessLeanRunArtifacts(tempDir, 'strategy-backtest');
     expect(report.blockers).toContainEqual(
-      expect.stringContaining('LEAN data monitor reports 4 failed data requests'),
+      expect.stringContaining(
+        'LEAN data monitor reports 4 failed data requests',
+      ),
+    );
+  });
+
+  it('rejects unlevered strategy evidence with oversized target exposure', () => {
+    const runId = tempDir.split('/').pop() ?? 'lean-acceptance';
+    writeArtifactSet(tempDir, {
+      runId,
+      insights: [{ id: 'i1', symbol: 'NVDA' }],
+      targets: [
+        { symbol: 'NVDA', targetWeight: 1.25, sourceInsightIds: ['i1'] },
+      ],
+      targetGrossExposurePct: 1.25,
+      targetMaxSingleNamePct: 1.25,
+      events: [{ id: '1', status: 'Filled', fillQuantity: 1, fillPrice: 100 }],
+      fills: [{ id: 'f1', orderId: '1', quantity: 1, price: 100 }],
+      statistics: { 'Total Orders': 1, 'End Equity': 100500 },
+      dataMonitorReport: {
+        'total-data-requests-count': 5,
+        'failed-data-requests-count': 0,
+        'failed-universe-data-requests-count': 0,
+      },
+      config: {
+        projectName: 'aggressive_llm_momentum',
+        algorithmVersion: 'v1',
+        parameters: {
+          'run-id': runId,
+          'validation-mode': 'historical-research',
+          'uses-static-meta-overlay': false,
+          'uses-static-ml-predictions': false,
+        },
+      },
+    });
+
+    const report = assessLeanRunArtifacts(tempDir, 'strategy-backtest');
+
+    expect(report.blockers).toEqual(
+      expect.arrayContaining([
+        'Portfolio target NVDA exceeds the unlevered absolute target weight cap.',
+        'Portfolio target gross exposure exceeds the current unlevered strategy cap.',
+      ]),
     );
   });
 });
@@ -193,6 +235,8 @@ function writeArtifactSet(
     dataMonitorReport?: Record<string, number>;
     config: Record<string, unknown>;
     riskNotes?: string[];
+    targetGrossExposurePct?: number;
+    targetMaxSingleNamePct?: number;
   },
 ): void {
   writeJson(join(directory, 'insights.json'), {
@@ -204,8 +248,10 @@ function writeArtifactSet(
     leanRunId: input.runId,
     asOf: '2026-05-24T00:00:00.000Z',
     targets: input.targets,
-    grossExposurePct: input.targets.length ? 0.35 : 0,
-    maxSingleNamePct: input.targets.length ? 0.35 : 0,
+    grossExposurePct:
+      input.targetGrossExposurePct ?? (input.targets.length ? 0.35 : 0),
+    maxSingleNamePct:
+      input.targetMaxSingleNamePct ?? (input.targets.length ? 0.35 : 0),
     riskNotes: input.riskNotes ?? [],
   });
   writeJson(join(directory, 'order_events.json'), { events: input.events });

--- a/backend/src/modules/v1-pilot/lean/lean-run-acceptance.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-run-acceptance.ts
@@ -57,6 +57,8 @@ type DataMonitorReport = {
 
 const HYDRATION_NOTE = 'hydrated_from_lean_summary_only';
 const STRATEGY_VALIDATION_MODE = 'historical-research';
+const MAX_UNLEVERED_ABSOLUTE_TARGET_WEIGHT = 1;
+const MAX_UNLEVERED_GROSS_TARGET_WEIGHT = 1;
 
 export function assessLeanRunArtifacts(
   resultDirectory: string,
@@ -284,6 +286,14 @@ function targetIntegrityBlockers(
     if (!Number.isFinite(target.targetWeight)) {
       blockers.push(`Portfolio target ${target.symbol} has non-finite weight.`);
     }
+    if (
+      Number.isFinite(target.targetWeight) &&
+      Math.abs(target.targetWeight) > MAX_UNLEVERED_ABSOLUTE_TARGET_WEIGHT
+    ) {
+      blockers.push(
+        `Portfolio target ${target.symbol} exceeds the unlevered absolute target weight cap.`,
+      );
+    }
     const sourceInsightIds = target.sourceInsightIds ?? [];
     if (sourceInsightIds.length === 0) {
       blockers.push(
@@ -312,6 +322,15 @@ function targetIntegrityBlockers(
   if (targets && Math.abs(maxSingle - targets.maxSingleNamePct) > 0.0001) {
     blockers.push(
       'Portfolio target max single-name exposure does not match targets.',
+    );
+  }
+  if (
+    targets &&
+    Number.isFinite(targets.grossExposurePct) &&
+    targets.grossExposurePct > MAX_UNLEVERED_GROSS_TARGET_WEIGHT
+  ) {
+    blockers.push(
+      'Portfolio target gross exposure exceeds the current unlevered strategy cap.',
     );
   }
 

--- a/backend/src/modules/v1-pilot/lean/lean-run-import.service.spec.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-run-import.service.spec.ts
@@ -1,7 +1,8 @@
 import { Test } from '@nestjs/testing';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
+import { Repository } from 'typeorm';
 import { LeanRun } from '../../../entities/lean-run.entity';
 import { PortfolioTargetSnapshot } from '../../../entities/portfolio-target-snapshot.entity';
 import { LeanRunImportService } from './lean-run-import.service';
@@ -9,6 +10,7 @@ import { LeanLocalSimulatorService } from './lean-local-simulator.service';
 
 describe('LeanRunImportService', () => {
   let service: LeanRunImportService;
+  let targetRepository: Repository<PortfolioTargetSnapshot>;
   const tempRoot = join(process.cwd(), 'tmp-test-lean-runs');
 
   beforeAll(async () => {
@@ -25,6 +27,7 @@ describe('LeanRunImportService', () => {
       providers: [LeanRunImportService, LeanLocalSimulatorService],
     }).compile();
     service = moduleRef.get(LeanRunImportService);
+    targetRepository = moduleRef.get(getRepositoryToken(PortfolioTargetSnapshot));
   });
 
   afterAll(() => {
@@ -140,5 +143,11 @@ describe('LeanRunImportService', () => {
     expect(imported.runtime).toBe('quantconnect-cloud');
     expect(imported.cloudProjectId).toBe('32077023');
     expect(imported.cloudBacktestId).toBe('ecd033aae81ec9f98e1c24b4c5a58d4c');
+    await expect(
+      targetRepository.findOne({ where: { id: 'targets-qc-import-test' } }),
+    ).resolves.toMatchObject({
+      leanRunId: 'qc-import-test',
+      targetHash: expect.any(String),
+    });
   });
 });

--- a/backend/src/modules/v1-pilot/lean/lean-run-import.service.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-run-import.service.ts
@@ -10,12 +10,12 @@ import { Repository } from 'typeorm';
 import { LeanRun } from '../../../entities/lean-run.entity';
 import { PortfolioTargetSnapshot } from '../../../entities/portfolio-target-snapshot.entity';
 import { LeanRunResult } from './lean-run.types';
-import { LeanPortfolioTargetsPayload } from './lean-run.types';
 import { hashObject } from '../../../shared/hash.util';
 import {
   LeanAcceptanceMode,
   assessLeanRunArtifacts,
 } from './lean-run-acceptance';
+import { importPortfolioTargetSnapshot } from './lean-portfolio-target-importer';
 
 @Injectable()
 export class LeanRunImportService {
@@ -75,6 +75,11 @@ export class LeanRunImportService {
       where: { importIdempotencyKey: importKey },
     });
     if (existing) {
+      await importPortfolioTargetSnapshot(
+        this.targetRepository,
+        existing.runId,
+        existing.portfolioTargetsRef,
+      );
       return existing;
     }
 
@@ -113,7 +118,11 @@ export class LeanRunImportService {
         importIdempotencyKey: importKey,
       }),
     );
-    await this.importPortfolioTargets(saved.runId, result.portfolioTargetsRef!);
+    await importPortfolioTargetSnapshot(
+      this.targetRepository,
+      saved.runId,
+      result.portfolioTargetsRef,
+    );
     return saved;
   }
 
@@ -210,32 +219,6 @@ export class LeanRunImportService {
       throw new BadRequestException(`Unsafe LEAN run path in marker: ${runId}`);
     }
     return resultDirectory;
-  }
-
-  private async importPortfolioTargets(
-    leanRunId: string,
-    portfolioTargetsRef: string,
-  ): Promise<PortfolioTargetSnapshot> {
-    const payload = JSON.parse(
-      readFileSync(portfolioTargetsRef, 'utf8'),
-    ) as LeanPortfolioTargetsPayload;
-    const existing = await this.targetRepository.findOne({
-      where: { id: payload.id },
-    });
-    if (existing) {
-      return existing;
-    }
-    return this.targetRepository.save(
-      this.targetRepository.create({
-        id: payload.id,
-        leanRunId: payload.leanRunId ?? leanRunId,
-        asOf: payload.asOf,
-        targets: payload.targets,
-        grossExposurePct: payload.grossExposurePct,
-        maxSingleNamePct: payload.maxSingleNamePct,
-        targetHash: payload.targetHash ?? hashObject(payload),
-      }),
-    );
   }
 
   private runtimeFromConfig(config: {

--- a/backend/src/modules/v1-pilot/paper/lean-paper-bridge.service.ts
+++ b/backend/src/modules/v1-pilot/paper/lean-paper-bridge.service.ts
@@ -75,7 +75,12 @@ export class LeanPaperBridgeService {
     if (!snapshot?.targets.length) {
       throw new Error('Latest LEAN run has no portfolio targets.');
     }
-    const scopedIdempotencyKey = `${idempotencyKey}:${latestRun.runId}:${snapshot.id}`;
+    const scopedIdempotencyKey = [
+      idempotencyKey,
+      latestRun.runId,
+      snapshot.id,
+      snapshot.targetHash ?? 'no-target-hash',
+    ].join(':');
     const leanRunEvidenceRef = `lean-run:${latestRun.runId}`;
     const targetEvidenceRef = `portfolio-target:${snapshot.id}`;
     const replayEvidenceRefs =
@@ -296,7 +301,14 @@ export class LeanPaperBridgeService {
 
   private buildOrders(targets: PortfolioTargetItemContract[]) {
     const selectedTargets = targets
-      .filter((target) => Number.isFinite(target.targetWeight))
+      .filter(
+        (target) =>
+          Number.isFinite(target.targetWeight) && target.targetWeight > 0,
+      )
+      .sort(
+        (left, right) =>
+          Math.abs(right.targetWeight) - Math.abs(left.targetWeight),
+      )
       .slice(0, 2);
     const cappedPercents = selectedTargets.map((target) =>
       Math.min(

--- a/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.ts
+++ b/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.ts
@@ -4,7 +4,7 @@
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MoreThanOrEqual, Repository } from 'typeorm';
+import { In, MoreThanOrEqual, Repository } from 'typeorm';
 import { AlphaDecision } from '../../../entities/alpha-decision.entity';
 import {
   ResearchJobRecord,
@@ -315,12 +315,18 @@ export class CapitalEvidenceSliceService {
     alphaStartedAt: Date;
     alphaStep: CapitalEvidenceStep;
   }): Promise<CapitalVariantOutcome[]> {
-    const decisions = await this.alphaRepository.find({
-      where: {
-        createdAt: MoreThanOrEqual(input.alphaStartedAt),
-      },
-      order: { createdAt: 'DESC' },
-    });
+    const alphaDecisionIds = this.alphaDecisionIds(input.alphaStep);
+    const decisions = alphaDecisionIds.length
+      ? await this.alphaRepository.find({
+          where: { id: In(alphaDecisionIds) },
+          order: { createdAt: 'DESC' },
+        })
+      : await this.alphaRepository.find({
+          where: {
+            updatedAt: MoreThanOrEqual(input.alphaStartedAt),
+          },
+          order: { createdAt: 'DESC' },
+        });
 
     const outcomes: CapitalVariantOutcome[] = [];
     for (const variant of DEFAULT_CAPITAL_VARIANTS) {
@@ -374,6 +380,18 @@ export class CapitalEvidenceSliceService {
       });
     }
     return outcomes;
+  }
+
+  private alphaDecisionIds(alphaStep: CapitalEvidenceStep): string[] {
+    if (!alphaStep.output || typeof alphaStep.output !== 'object') {
+      return [];
+    }
+    const output = alphaStep.output as Record<string, unknown>;
+    return [
+      ...this.stringArray(output.numericDecisionIds),
+      ...this.stringArray(output.llmDecisionIds),
+      ...this.stringArray(output.metaDecisionIds),
+    ];
   }
 
   private async recordResearchJob(input: {

--- a/backend/src/modules/v1-pilot/v1-pilot-orchestrator.service.ts
+++ b/backend/src/modules/v1-pilot/v1-pilot-orchestrator.service.ts
@@ -191,6 +191,11 @@ export class V1PilotOrchestratorService {
     llmFeatureCount: number;
     llmCount: number;
     metaCount: number;
+    featureIds: string[];
+    numericDecisionIds: string[];
+    llmFeatureIds: string[];
+    llmDecisionIds: string[];
+    metaDecisionIds: string[];
   }> {
     const snapshots =
       await this.featureSnapshotService.buildSnapshotsForUniverse(
@@ -214,6 +219,11 @@ export class V1PilotOrchestratorService {
       llmFeatureCount: llmFeatures.length,
       llmCount: llm.length,
       metaCount: meta.length,
+      featureIds: snapshots.map((snapshot) => snapshot.id),
+      numericDecisionIds: numeric.map((decision) => decision.id),
+      llmFeatureIds: llmFeatures.map((feature) => feature.id),
+      llmDecisionIds: llm.map((decision) => decision.id),
+      metaDecisionIds: meta.map((decision) => decision.id),
     };
   }
 

--- a/backend/src/modules/v1-pilot/v1-pilot-status-stage.builder.ts
+++ b/backend/src/modules/v1-pilot/v1-pilot-status-stage.builder.ts
@@ -236,7 +236,7 @@ export function buildV1NextActions(stages: V1SystemStage[]): string[] {
   }
   return [
     `Resolve ${firstBlocker.label}: ${firstBlocker.blockers[0] ?? firstBlocker.detail}`,
-    'Run ./scripts/run-v1-cycle after the blocker is resolved.',
+    'Run bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --json after the blocker is resolved.',
   ];
 }
 

--- a/backend/src/runtime/create-lincei-runtime.spec.ts
+++ b/backend/src/runtime/create-lincei-runtime.spec.ts
@@ -1,9 +1,20 @@
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import type { Repository } from 'typeorm';
 import { createLinceiRuntime } from './create-lincei-runtime';
+import { MarketDataBar } from '../entities/market-data-bar.entity';
+import { FeatureSnapshot } from '../entities/feature-snapshot.entity';
+import { AlphaDecision } from '../entities/alpha-decision.entity';
+import { LlmEventFeature } from '../entities/llm-event-feature.entity';
 
 describe('createLinceiRuntime', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
   it('creates a framework-neutral runtime without booting Nest', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'lincei-runtime-'));
     const runtime = await createLinceiRuntime({
@@ -23,4 +34,83 @@ describe('createLinceiRuntime', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it(
+    'can replay the alpha cycle without duplicate primary-key failures',
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'lincei-runtime-alpha-'));
+      const openAiEnvPath = join(dir, 'openai.env');
+      writeFileSync(openAiEnvPath, 'OPENAI_API_KEY=test-openai-key\n');
+      process.env.LINCEI_OPENAI_ENV_FILE = openAiEnvPath;
+      process.env.V1_UNIVERSE_SYMBOLS = 'SPY,QQQ';
+      const runtime = await createLinceiRuntime({
+        databasePath: join(dir, 'runtime.sqlite'),
+        synchronize: true,
+        dropSchema: true,
+        loadEnv: false,
+      });
+
+      try {
+        await seedBars(runtime.dataSource.getRepository(MarketDataBar));
+
+        const first = await runtime.orchestrator.runAlphaCycle();
+        const second = await runtime.orchestrator.runAlphaCycle();
+
+        expect(first).toMatchObject({
+          featureCount: 2,
+          numericCount: 2,
+          llmFeatureCount: 6,
+          llmCount: 6,
+          metaCount: 2,
+        });
+        expect(second).toEqual(first);
+        await expect(
+          runtime.dataSource.getRepository(FeatureSnapshot).count(),
+        ).resolves.toBe(2);
+        await expect(
+          runtime.dataSource.getRepository(LlmEventFeature).count(),
+        ).resolves.toBe(6);
+        await expect(
+          runtime.dataSource.getRepository(AlphaDecision).count(),
+        ).resolves.toBe(10);
+      } finally {
+        await runtime.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    20_000,
+  );
 });
+
+async function seedBars(repository: Repository<MarketDataBar>) {
+  const availabilityTimestamp = new Date(Date.now() - 60_000).toISOString();
+  const symbols = ['SPY', 'QQQ'];
+  const bars = symbols.flatMap((symbol) =>
+    [3, 2, 1].map((daysAgo, index) => {
+      const timestamp = new Date(
+        Date.now() - daysAgo * 86_400_000,
+      ).toISOString();
+      const close = 100 + index * 2 + (symbol === 'QQQ' ? 5 : 0);
+      return {
+        datasetId: 'v1-lean-universe',
+        provider: 'manual' as const,
+        sourceRef: `test:${symbol}:${index}`,
+        symbol,
+        timeframe: '1d',
+        timestamp,
+        availabilityTimestamp,
+        currency: 'USD',
+        open: close - 1,
+        high: close + 1,
+        low: close - 2,
+        close,
+        adjustedClose: close,
+        volume: 1_000_000 + index,
+        notes: [],
+        brokerExecutionEnabled: false,
+        liveTradingEnabled: false,
+      };
+    }),
+  );
+  await repository.save(bars);
+}

--- a/backend/src/runtime/create-lincei-runtime.ts
+++ b/backend/src/runtime/create-lincei-runtime.ts
@@ -168,8 +168,15 @@ export async function createLinceiRuntime(
     repo(LeanRun),
     repo(PortfolioTargetSnapshot),
   );
-  const leanCloudRunner = new LeanCloudRunner(leanCliRunner, repo(LeanRun));
-  const leanCloudManualImporter = new LeanCloudManualImporter(repo(LeanRun));
+  const leanCloudRunner = new LeanCloudRunner(
+    leanCliRunner,
+    repo(LeanRun),
+    repo(PortfolioTargetSnapshot),
+  );
+  const leanCloudManualImporter = new LeanCloudManualImporter(
+    repo(LeanRun),
+    repo(PortfolioTargetSnapshot),
+  );
   const researchFactoryService = new ResearchFactoryService(
     repo(ResearchHypothesis),
     repo(ResearchJobRecord),

--- a/result.md
+++ b/result.md
@@ -1,213 +1,139 @@
-# Lincei Quant Research Engine: Capital Evidence Flow
+# Lincei Quant Research Engine: Current Capital Evidence Status
 
 Status: supporting review note.
 
-Last checked: 2026-05-28 on `Darwin arm64`.
+Last checked: 2026-05-29 on `Darwin arm64`.
 
-Source of truth: [SPEC.md](SPEC.md), [terminology.md](terminology.md), and `docs/spec/`. This file is not the spec. It explains how the current implementation decides, tests, blocks, and eventually prepares for self-funded capital allocation.
+Source of truth: [SPEC.md](SPEC.md), [terminology.md](terminology.md), and `docs/spec/`. This file explains the current implementation state in plain language. It is not the normative spec.
 
-## 1. Current Conclusion
+## 1. One-line Conclusion
 
-The project is now organized around this capital evidence loop:
+The project can now run data ingestion, alpha replay, QuantConnect Cloud backtest import, portfolio target import, historical paper replay, shadow recording, learning, and pre-trade risk check through the `lincei` CLI.
 
-`research corpus -> hypothesis -> point-in-time data -> LLM-derived features -> alpha variants -> LEAN / QuantConnect validation -> portfolio target -> paper/shadow -> reconciliation -> promotion decision -> broker-write candidate status`
+It is still **not ready to trade real money** because the current paper cycle, Toss read-only reconciliation, broker-write flags, and broker credentials are intentionally missing or blocked.
 
-The latest direct run proves the new CLI/runtime path executes, but it correctly ends as `blocked`.
-
-Latest direct command:
-
-```bash
-bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --json
-```
-
-Latest direct run id: `capital-evidence-20260528081047-3d32260289b0`
-
-Latest status: `blocked`
-
-Why blocked:
-
-- Point-in-time market data is not ready. `STOOQ_API_KEY` is missing for the active LEAN universe.
-- Alpha generation is blocked because active symbols such as `SMH` have insufficient daily bars.
-- No passed variant exists yet. The run retained three blocked ablation variant jobs.
-- QuantConnect Cloud REST credentials are missing: `QC_USER_ID` and `QC_API_TOKEN`.
-- No accepted LEAN strategy run exists for paper/shadow.
-- Promotion decision was created, but it is `blocked`.
-- Broker-write candidate remains blocked because real broker writes are still outside the active spec.
-
-## 2. Runtime And CLI Shape
+## 2. Current Flow
 
 ```mermaid
-graph TD
-    A["Operator"] --> B["lincei CLI<br/>backend/src/cli/lincei.ts"]
-    B --> C["Framework-neutral runtime<br/>backend/src/runtime/create-lincei-runtime.ts"]
-    C --> D["TypeORM SQLite ledgers"]
-    C --> E["V1 pilot services"]
-    C --> F["CapitalEvidenceSliceService"]
-    C --> G["Hono HTTP adapter<br/>backend/src/http/hono-app.ts"]
-    F --> H["Capital evidence run"]
-    G --> H
+flowchart TD
+    A["Research corpus<br/>Alpha Architect hypotheses"] --> B["Point-in-time data<br/>Stooq market bars + text evidence"]
+    B --> C["Feature snapshots"]
+    C --> D["Numeric alpha decisions"]
+    B --> E["LLM-derived features"]
+    E --> F["LLM alpha decisions"]
+    D --> G["Combined/meta alpha decisions"]
+    F --> G
+    G --> H["Variant evidence<br/>numeric / LLM / combined"]
+    H --> I["QuantConnect Cloud backtest import"]
+    I --> J["Portfolio targets<br/>normalized target weights"]
+    J --> K["Historical paper replay"]
+    J --> L["Historical shadow record"]
+    K --> M["Reconciliation"]
+    L --> N["Learning / promotion decision"]
+    M --> O["Pre-trade risk check"]
+    N --> O
+    O --> P["Real broker write<br/>blocked by design"]
 ```
 
-Important implementation note: the CLI is TypeScript and invoked through Bun scripts, but this machine cannot run the TypeORM `better-sqlite3` ledger under Bun's JavaScript runtime. The `lincei` script therefore executes with `ts-node` under Node while still being managed by `bun run`. That avoids a second CLI language and avoids duplicating ledger/risk/promotion logic.
+Important boundary: the LLM participates before the backtest by producing typed semantic features and LLM alpha decisions. It does not receive broker credentials, does not create raw broker orders, and does not decide final broker quantities.
 
-Canonical commands:
+## 3. What Is Working Now
+
+| Area | Current result |
+| --- | --- |
+| Stooq market data | `STOOQ_API_KEY` is configured locally; market ingestion can pass. |
+| Alpha replay | `alpha run` can be repeated without duplicate key crashes. Feature snapshots, LLM event features, and alpha decisions are upserted idempotently. |
+| Variant evidence | Numeric / LLM / combined variants are recorded, including passed, failed, blocked, and flat/no-order outcomes. |
+| QuantConnect Cloud | REST credentials work. Project `32097697` and backtest `ecd033aae81ec9f98e1c24b4c5a58d4c` were imported. |
+| Cloud strategy evidence | Imported run `qc-import-ecd033aae81e` is `passed`, runtime `quantconnect-cloud`, promotion eligible as backtest evidence. |
+| Portfolio target import | Cloud portfolio target snapshot is persisted to SQLite. Current target count is 22. |
+| Target normalization | Cloud symbol suffixes like `NVDA RHM8UTD8DT2D` are normalized to broker-facing tickers like `NVDA`. Sell fills no longer double-flip sign. |
+| Paper replay | Historical paper replay plan `3` is `reconciled` with matched reconciliation and 2 fills. |
+| Shadow record | Historical target shadow record exists and reconciles as matched. |
+| Pre-trade risk check | Runs fail-closed and reports concrete blockers. |
+
+Latest important target numbers:
+
+| Metric | Value | Meaning |
+| --- | --- | --- |
+| `targetCount` | 22 | Number of imported target rows. |
+| `grossExposurePct` | 0.257951 | Stored as target-weight fraction, about 25.8% gross target exposure. |
+| `maxSingleNamePct` | 0.062675 | Stored as target-weight fraction, about 6.3% max single-name target. |
+
+This fixed a serious earlier issue: Cloud targets were previously derived as roughly 48x gross exposure because sell fills were counted with the wrong sign.
+
+## 4. What Is Still Blocked
+
+| Area | Status | Why it matters |
+| --- | --- | --- |
+| Current paper cycle | `missing` | Historical replay exists, but live preflight requires current paper trading evidence for the latest target. |
+| Current shadow evidence | `blocked for promotion` | Latest shadow record is `historical_target_replay`; promotion requires `current_live_shadow`. |
+| Broker read-only | `blocked` | Current broker snapshot is `simulated`, not a matched Toss read-only poll. |
+| Broker credentials | `missing` | Toss credential env is not configured. |
+| Broker-write flags | `not ready` | `brokerWriteEnabled`, `liveTradingEnabled`, schema verification, cancel/flatten, and open-order polling flags remain false. |
+| Real broker writes | `deferred` | Requires a separate user-approved broker-write implementation spec. |
+| Darwinex/Zero | `deferred` | Should wait until self-funded capital evidence and track record are stronger. |
+
+Latest preflight blocker summary:
+
+```text
+status: blocked
+main blockers:
+- Only historical paper replay exists for the latest LEAN target.
+- Toss read-only broker snapshot is missing.
+- Broker snapshot reconciliation is not matched.
+- Broker credentials are missing.
+- Broker-write/live-trading/schema/cancel/open-order flags are not ready.
+```
+
+## 5. Why Current Paper Is Still Missing
+
+There are two paper modes:
+
+| Mode | Meaning | Current state |
+| --- | --- | --- |
+| Historical paper replay | Replays imported historical backtest targets through the paper ledger to prove plumbing and reconciliation. | Working: plan `3`, matched. |
+| Current paper cycle | Uses current-market target evidence and is allowed to count toward live preflight. | Still blocked. |
+
+The current paper run correctly refuses to treat historical Cloud backtest targets as current-market readiness:
+
+```text
+Paper risk evaluation DENY:
+- Market data is stale for the active policy.
+- Paper execution requires human approval.
+- Human approval is required outside dry-run mode.
+```
+
+This is the right safety behavior. It means the next core implementation should not be another dashboard. It should create a clean current-market paper cycle path.
+
+## 6. Next Work, In Order
+
+| Priority | Work | Direct proof |
+| --- | --- | --- |
+| P0 | Build a current-market paper cycle path from fresh alpha decisions and normalized long-only target candidates. Historical Cloud backtest targets must remain replay evidence only. | `bun --cwd=backend run lincei -- paper run --json` returns a reconciled current paper plan. |
+| P1 | Add explicit operator approval or dry-run approval handling for current paper execution without enabling real broker writes. | Paper run records approval custody and stays broker-write disabled. |
+| P2 | Implement Toss read-only account/open-order polling and reconciliation. No write calls. | `preflight run` no longer says broker snapshot is simulated or stale. |
+| P3 | Keep QuantConnect Cloud import as promotion-quality backtest evidence, but separate it from current-market target generation. | Status shows Cloud evidence and current paper evidence separately. |
+| P4 | Re-run learning and promotion after current paper + current shadow exist. | Promotion blocker moves from `historical_target_replay` to any remaining real blocker. |
+| P5 | Only after the above, draft the broker-write spec for user approval. | No implementation before explicit approval. |
+
+## 7. Commands Used For Review
 
 ```bash
-bun --cwd=backend run lincei -- help
+bun --cwd=backend run lincei -- qc import-backtest --project-id 32097697 --backtest-id ecd033aae81ec9f98e1c24b4c5a58d4c --json
+bun --cwd=backend run lincei -- paper replay --json
+bun --cwd=backend run lincei -- shadow run --json
+bun --cwd=backend run lincei -- learning run --json
+bun --cwd=backend run lincei -- preflight run --json
 bun --cwd=backend run lincei -- capital status --json
-bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --json
 ```
 
-Legacy script command names still work through `bun run v1:cli -- ...` while migration continues.
+Validation run:
 
-## 3. Decision Flow
-
-```mermaid
-graph TD
-    A["Research corpus<br/>Alpha Architect references"] --> B["Hypothesis registry<br/>ResearchHypothesis"]
-    B --> C["Search space lock<br/>numeric / LLM / combined variants"]
-    C --> D["Point-in-time market data<br/>MarketDataBar + FeatureSnapshot"]
-    C --> E["Point-in-time text evidence<br/>RawEvidenceRecord"]
-    D --> F["Numeric alpha<br/>AlphaDecision(source=numeric)"]
-    E --> G["LLM-derived features<br/>LlmEventFeature"]
-    G --> H["LLM alpha<br/>AlphaDecision(source=llm)"]
-    F --> I["Combined alpha<br/>AlphaDecision(source=meta)"]
-    H --> I
-    F --> J["LEAN validation"]
-    H --> J
-    I --> J
-    J --> K["QuantConnect Cloud import<br/>promotion-quality backtest evidence"]
-    K --> L["PortfolioTargetSnapshot"]
-    L --> M["Paper trading / shadow trading"]
-    M --> N["Reconciliation + outcome labels"]
-    N --> O["PromotionDecision"]
-    O --> P["Broker-write candidate status<br/>blocked until separate approval"]
+```bash
+cd backend
+bun run test -- src/runtime/create-lincei-runtime.spec.ts src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts src/modules/v1-pilot/lean/lean-cloud-artifact-mapper.spec.ts src/modules/v1-pilot/lean/lean-run-acceptance.spec.ts src/modules/v1-pilot/lean/lean-run-import.service.spec.ts src/modules/v1-pilot/lean/lean-cloud.runner.spec.ts src/modules/v1-pilot/paper/lean-paper-bridge.service.spec.ts src/modules/v1-pilot/v1-pilot-status-stage.builder.spec.ts
+bun run build
 ```
 
-LLM involvement is before the backtest. The LLM reads point-in-time text evidence and produces typed semantic features and LLM alpha decisions. It does not see broker credentials, it does not create raw broker payloads, and it does not choose final order quantities.
-
-## 4. Actual Latest Run
-
-| Stage | Result | Evidence |
-| --- | --- | --- |
-| Research corpus | `passed` | 40 hypotheses, 15 P1 candidates |
-| Semantic evidence ingest | `passed` | 80 Hugging Face FOMC records created |
-| Point-in-time data | `blocked` | Missing `STOOQ_API_KEY`; local LEAN daily export blocked |
-| Alpha cycle | `blocked` | Insufficient bars for active universe symbol `SMH` |
-| Variant retention | `blocked` | 3 retained ablation jobs, all blocked |
-| Local LEAN validation | `skipped` | Data preparation blocked |
-| QuantConnect Cloud check | `blocked` | Missing `QC_USER_ID` / `QC_API_TOKEN` |
-| Paper cycle | `blocked` | No accepted LEAN strategy run imported |
-| Shadow trading | `blocked` | No accepted LEAN run or portfolio target |
-| Learning / promotion | `blocked` | Promotion decision created as blocked |
-| Broker-write preflight | `blocked` | No current evidence, no real broker-read-only reconciliation, broker-write out of scope |
-
-Retained variants from the latest run:
-
-| Variant | Alpha source | Status | Job id |
-| --- | --- | --- | --- |
-| `trend-regime-numeric-v1` | `numeric` | `blocked` | `ablation-ca727ce31762` |
-| `semantic-llm-v1` | `llm` | `blocked` | `ablation-34381ad35aff` |
-| `trend-regime-combined-v1` | `meta` | `blocked` | `ablation-d7bd61350b6e` |
-
-Promotion decision from the latest run:
-
-| Field | Value |
-| --- | --- |
-| id | `promotion-20260528081102` |
-| status | `blocked` |
-| attempted variants | 3 |
-| failed or blocked variants | 3 |
-| passed variants | 0 |
-
-This is useful progress: the system now records losers/blocked variants instead of silently having no variant evidence. It is not yet evidence that a strategy earns money.
-
-## 5. Component I/O
-
-| Component | Input | Output | Ledger/artifact |
-| --- | --- | --- | --- |
-| Research factory | Alpha Architect index and strategy register | `ResearchHypothesis`, corpus jobs | `research_hypotheses`, `research_job_records` |
-| Market data preparation | universe, provider, dataset id | bars, LEAN daily data readiness | `market_data_bars`, LEAN data files |
-| Semantic evidence ingest | Hugging Face FOMC CSV or local source file | point-in-time text records | `raw_evidence_records` |
-| Feature snapshot builder | market bars with availability timestamps | numeric feature rows | `feature_snapshots` |
-| LLM feature builder | raw evidence refs, feature refs, prompt/model version | semantic event/macro/risk features | `llm_event_features` |
-| Alpha services | numeric features and LLM-derived features | numeric, LLM, and meta alpha decisions | `alpha_decisions` |
-| Capital evidence slice | hypothesis, variants, current ledgers | retained variant jobs and promotion report | `research_job_records`, `promotion_decisions` |
-| LEAN / Cloud import | alpha exports, LEAN artifacts, Cloud ids | run metrics and target snapshots | `lean_runs`, `portfolio_target_snapshots`, `artifacts/lean-runs/*` |
-| Paper/shadow | portfolio target and risk policy | paper order plan or would-have-traded record | `paper_order_plans`, `live_shadow_records` |
-| Pre-trade risk check | promotion, broker read-only snapshot, reconciliation, limits | `ready` or `blocked` | `live_pilot_status_records` |
-
-## 6. Parallelization
-
-Current `capital run` is intentionally single-worker (`--max-backtest-workers 1`) because portfolio target consolidation, paper/shadow, reconciliation, and pre-trade risk checks must remain single-writer.
-
-Safe future parallelism is before promotion:
-
-```mermaid
-graph LR
-    A["Locked hypothesis"] --> B["Market data jobs"]
-    A --> C["Text evidence jobs"]
-    A --> D["Numeric feature jobs"]
-    A --> E["LLM-derived feature jobs"]
-    D --> F["Numeric-only ablations"]
-    E --> G["LLM-only ablations"]
-    D --> H["Combined ablations"]
-    E --> H
-    F --> I["Backtest sweep"]
-    G --> I
-    H --> I
-    I --> J["Single promotion review"]
-```
-
-Rule: parallel jobs may create evidence, but they must not write final portfolio targets, paper/shadow execution intent, reconciliation state, or broker-write status concurrently.
-
-## 7. Money Boundary
-
-Self-funded capital allocation is the main long-term objective, but the current implementation still blocks real account mutation.
-
-Money can enter only after all of these are true:
-
-1. At least one hypothesis has retained numeric-only, LLM-only, and combined variants.
-2. A variant has passed direct validation, including real QuantConnect Cloud import.
-3. Current paper/shadow evidence exists for the same target.
-4. Reconciliation is matched.
-5. Outcome labels and promotion decision are recorded.
-6. Real broker read-only cash/position/open-order state is reconciled.
-7. A separate broker-write spec is explicitly approved.
-8. Pre-trade risk check returns `ready`.
-
-Darwinex/Zero remains later. It should use a self-funded-capital deployment-grade signal and track record; it should not be built ahead of the core capital evidence loop.
-
-## 8. Immediate Next Implementation Targets
-
-| Priority | Work | Why |
-| --- | --- | --- |
-| P0 | Make the selected capital universe and active LEAN universe align | Latest run defaulted to `SPY,QQQ,TLT,IEF`, but active LEAN universe still required symbols like `SMH`. |
-| P1 | Provide point-in-time market data without manual blocking | `STOOQ_API_KEY` or another approved data source is required before alpha can run. |
-| P2 | Run alpha cycle with real features and retained variant jobs | Need at least one passed and one failed/blocked variant for selected-run-bias protection. |
-| P3 | Import real QuantConnect Cloud backtest by `projectId/backtestId` | Local LEAN/simulator is not promotion evidence. |
-| P4 | Produce current paper/shadow and reconciliation artifacts | Historical or missing targets do not prove current readiness. |
-| P5 | Keep broker writes blocked until the separate spec is approved | This prevents accidental live account mutation before evidence exists. |
-
-## 9. Review Pointers
-
-| File | What to review |
-| --- | --- |
-| [backend/src/cli/lincei.ts](backend/src/cli/lincei.ts) | New CLI command surface and legacy command compatibility |
-| [backend/src/runtime/create-lincei-runtime.ts](backend/src/runtime/create-lincei-runtime.ts) | Framework-neutral service composition and DataSource lifecycle |
-| [backend/src/http/hono-app.ts](backend/src/http/hono-app.ts) | Thin Hono adapter over the same runtime |
-| [backend/src/modules/v1-pilot/research/capital-evidence-slice.service.ts](backend/src/modules/v1-pilot/research/capital-evidence-slice.service.ts) | Capital evidence vertical slice and retained variant job recording |
-| [backend/src/modules/v1-pilot/research/research-factory.service.ts](backend/src/modules/v1-pilot/research/research-factory.service.ts) | Hypothesis registry and selected-run-bias check |
-| [backend/src/modules/v1-pilot/live/live-preflight.service.ts](backend/src/modules/v1-pilot/live/live-preflight.service.ts) | Fail-closed broker-write pre-trade risk check |
-
-## 10. Final Judgment
-
-The project is still not ready to trade real money, but the implementation is closer to the right shape. The core gap is no longer "there is no operator CLI"; it is now concrete:
-
-- data source blocked;
-- no passed variant;
-- no real Cloud import;
-- no current target/paper/shadow reconciliation;
-- broker-write approval still absent.
-
-That is the right kind of blocked state. It tells us exactly what must be fixed before self-funded capital can be considered.
+Result: 8 focused suites / 26 tests passed, backend build passed.


### PR DESCRIPTION
## Summary
- Make alpha replay idempotent across feature, LLM feature, and alpha decision ledgers.
- Normalize QuantConnect Cloud target imports and persist portfolio target snapshots on re-import.
- Refresh paper replay, preflight status, and result.md around the current capital evidence blockers.

## Validation
- Focused backend Jest suites passed.
- Backend build passed.
- Direct Cloud import, paper replay, shadow, learning, preflight, and status commands were run; preflight remains correctly blocked for current-paper and broker-read-only readiness.