### PR TITLE
Add bounded capital evidence triage

### DIFF
--- a/backend/src/cli/capital-triage.spec.ts
+++ b/backend/src/cli/capital-triage.spec.ts
@@ -1,0 +1,105 @@
+import { V1PilotSystemStatus } from '../modules/v1-pilot/v1-pilot-status.types';
+import { buildCapitalTriage } from './capital-triage';
+
+describe('buildCapitalTriage', () => {
+  it('returns one bounded capital run action for broker-boundary blockers', () => {
+    const result = buildCapitalTriage(
+      statusFixture({
+        key: 'broker_read_only',
+        blockers: ['Broker read-only snapshot is simulated.'],
+      }),
+    );
+
+    expect(result.recommendedAction.key).toBe('capital-run');
+    expect(result.recommendedAction.command).toContain('capital run');
+    expect(result.recommendedAction.command).toContain('--step-timeout-ms');
+    expect(result.blockers).toEqual([
+      'Broker read-only snapshot is simulated.',
+    ]);
+    expect(result.brokerBoundary.brokerWriteInScope).toBe(false);
+  });
+
+  it('routes Cloud import blockers to the QuantConnect Cloud listing command', () => {
+    const result = buildCapitalTriage(
+      statusFixture({
+        key: 'cloud_import',
+        blockers: ['QuantConnect Cloud backtest import is missing.'],
+      }),
+    );
+
+    expect(result.recommendedAction.key).toBe('quantconnect-cloud-import');
+    expect(result.recommendedAction.command).toContain('qc list-backtests');
+    expect(result.recommendedAction.reason).toContain(
+      'QuantConnect Cloud backtest results',
+    );
+  });
+});
+
+function statusFixture(stage: {
+  key: string;
+  blockers: string[];
+}): V1PilotSystemStatus {
+  return {
+    checkedAt: '2026-05-31T00:00:00.000Z',
+    verdict: 'blocked',
+    currentMilestone: {
+      key: 'self-funded-capital-evidence',
+      label: 'Self-funded capital evidence',
+      verdict: 'blocked',
+      readyStageCount: 0,
+      blockedStageCount: 1,
+      missingStageCount: 0,
+      currentStageCount: 1,
+      deferredStageCount: 0,
+    },
+    leanRun: null,
+    cloudRun: null,
+    alpha: {
+      featureSnapshotCount: 0,
+      numericDecisionCount: 0,
+      llmDecisionCount: 0,
+      metaDecisionCount: 0,
+      mlModelStatus: 'blocked',
+    },
+    research: {
+      hypothesisCount: 0,
+      p1CandidateCount: 0,
+      outOfScopeCount: 0,
+      variantJobCount: 0,
+      passedVariantJobCount: 0,
+      failedOrBlockedVariantJobCount: 0,
+    },
+    portfolioTarget: {
+      targetCount: 0,
+    },
+    paper: {
+      status: 'blocked',
+      fillCount: 0,
+    },
+    broker: {
+      snapshotStatus: 'blocked',
+      openOrderCount: 0,
+    },
+    livePilot: {
+      realOrderSent: false,
+    },
+    preflight: {
+      status: 'blocked',
+      submitted: false,
+      blockers: ['Broker-write path is blocked.'],
+    } as unknown as V1PilotSystemStatus['preflight'],
+    stages: [
+      {
+        key: stage.key,
+        label: stage.key,
+        status: 'blocked',
+        scope: 'current',
+        blocksCurrentMilestone: true,
+        detail: 'blocked for test',
+        blockers: stage.blockers,
+        refs: ['test-ref'],
+      },
+    ],
+    nextActions: ['Run triage.'],
+  };
+}

--- a/backend/src/cli/capital-triage.ts
+++ b/backend/src/cli/capital-triage.ts
@@ -1,0 +1,148 @@
+import type {
+  V1PilotSystemStatus,
+  V1SystemStage,
+} from '../modules/v1-pilot/v1-pilot-status.types';
+
+export interface CapitalTriageResult {
+  status: V1PilotSystemStatus['verdict'];
+  checkedAt: string;
+  currentMilestone: V1PilotSystemStatus['currentMilestone'];
+  recommendedAction: {
+    key: string;
+    label: string;
+    command: string;
+    reason: string;
+  };
+  blockers: string[];
+  supportingRefs: string[];
+  brokerBoundary: {
+    brokerWriteInScope: false;
+    note: string;
+  };
+  currentStages: Array<{
+    key: string;
+    status: string;
+    detail: string;
+    blockers: string[];
+    refs: string[];
+  }>;
+}
+
+export function buildCapitalTriage(
+  status: V1PilotSystemStatus,
+): CapitalTriageResult {
+  const currentStages = status.stages.filter(
+    (stage) => stage.scope === 'current' && stage.blocksCurrentMilestone,
+  );
+  const firstBlocker =
+    currentStages.find((stage) => stage.status === 'blocked') ??
+    currentStages.find((stage) => stage.status === 'missing');
+  const selected = firstBlocker ?? currentStages[currentStages.length - 1];
+  const recommendedAction = selected
+    ? actionForStage(selected)
+    : {
+        key: 'status',
+        label: 'Inspect capital status',
+        command: 'bun --cwd=backend run lincei -- capital status --json',
+        reason: 'No current milestone stage was available for triage.',
+      };
+
+  return {
+    status: status.verdict,
+    checkedAt: status.checkedAt,
+    currentMilestone: status.currentMilestone,
+    recommendedAction,
+    blockers: selected?.blockers ?? status.nextActions,
+    supportingRefs: selected?.refs ?? [],
+    brokerBoundary: {
+      brokerWriteInScope: false,
+      note: 'Broker writes and broker API integration remain out of scope for this broker-excluded evidence loop.',
+    },
+    currentStages: currentStages.map((stage) => ({
+      key: stage.key,
+      status: stage.status,
+      detail: stage.detail,
+      blockers: stage.blockers,
+      refs: stage.refs,
+    })),
+  };
+}
+
+function actionForStage(
+  stage: V1SystemStage,
+): CapitalTriageResult['recommendedAction'] {
+  switch (stage.key) {
+    case 'hypothesis_registry':
+      return {
+        key: 'research-corpus',
+        label: 'Refresh hypothesis registry',
+        command: 'bun --cwd=backend run lincei -- research corpus --json',
+        reason:
+          'The hypothesis registry is the first source for retained strategy variants.',
+      };
+    case 'variant_evidence':
+    case 'feature_store':
+    case 'alpha_decisions':
+      return {
+        key: 'capital-run',
+        label: 'Run broker-excluded capital evidence slice',
+        command:
+          'bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --step-timeout-ms 60000 --json',
+        reason:
+          'Feature, alpha, and retained variant blockers are resolved by rerunning the bounded capital evidence slice.',
+      };
+    case 'lean_backtest':
+      return {
+        key: 'lean-full-backtest',
+        label: 'Run local LEAN validation path',
+        command:
+          'bun --cwd=backend run lincei -- lean full-backtest --skip-alpha-cycle --skip-market-data-ingest --no-download-data --json',
+        reason:
+          'The local LEAN validation artifact is missing or blocked before Cloud promotion evidence can be reviewed.',
+      };
+    case 'cloud_import':
+      return {
+        key: 'quantconnect-cloud-import',
+        label: 'Import QuantConnect Cloud backtest results',
+        command:
+          'bun --cwd=backend run lincei -- qc list-backtests --project-name aggressive_llm_momentum --limit 10 --json',
+        reason:
+          'Promotion evidence requires imported QuantConnect Cloud backtest results tied to project/backtest ids.',
+      };
+    case 'portfolio_targets':
+    case 'paper_execution':
+      return {
+        key: 'paper-run',
+        label: 'Run current paper trading bridge',
+        command: 'bun --cwd=backend run lincei -- paper run --json',
+        reason:
+          'Current paper trading artifacts and reconciliation must exist before pre-trade risk checks are meaningful.',
+      };
+    case 'open_orders':
+      return {
+        key: 'preflight-run',
+        label: 'Run pre-trade risk check',
+        command: 'bun --cwd=backend run lincei -- preflight run --json',
+        reason:
+          'Open-order state is part of the fail-closed pre-trade risk check.',
+      };
+    case 'broker_read_only':
+    case 'live_preflight':
+      return {
+        key: 'capital-run',
+        label:
+          'Refresh broker-excluded evidence while broker boundary stays blocked',
+        command:
+          'bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --step-timeout-ms 60000 --json',
+        reason:
+          'The remaining blocker is broker-read-only or broker-write readiness, so the safe next action is to refresh non-broker promotion, paper trading, shadow trading, reconciliation, and learning artifacts.',
+      };
+    default:
+      return {
+        key: 'capital-status',
+        label: 'Inspect capital status',
+        command: 'bun --cwd=backend run lincei -- capital status --json',
+        reason: `No specialized triage action is defined for stage ${stage.key}.`,
+      };
+  }
+}

--- a/backend/src/cli/lincei.spec.ts
+++ b/backend/src/cli/lincei.spec.ts
@@ -15,6 +15,7 @@ describe('lincei CLI', () => {
 
     expect(exitCode).toBe(0);
     expect(lines.join('\n')).toContain('capital run');
+    expect(lines.join('\n')).toContain('capital triage');
     expect(lines.join('\n')).toContain('Hugging Face FOMC text evidence');
   });
 });

--- a/backend/src/cli/lincei.ts
+++ b/backend/src/cli/lincei.ts
@@ -9,8 +9,10 @@ import {
 } from '../runtime/create-lincei-runtime';
 import {
   DEFAULT_CAPITAL_HYPOTHESIS_ID,
+  CapitalEvidenceProgressEvent,
   CapitalEvidenceRunOptions,
 } from '../modules/v1-pilot/research/capital-evidence-slice.service';
+import { buildCapitalTriage } from './capital-triage';
 
 type CommandHandlerResult = {
   result?: unknown;
@@ -56,21 +58,32 @@ export async function runLinceiCli(
     return 0;
   }
 
-  const runtime = await createLinceiRuntime();
+  let restoreStdout: (() => void) | undefined;
+  let runtime: LinceiRuntime | undefined;
   try {
-    const handled = await dispatchCommand(runtime, args);
+    restoreStdout = json ? redirectStdoutToStderr() : undefined;
+    runtime = await createLinceiRuntime();
+    const handled = await dispatchCommand(runtime, args, { json });
+    await runtime.close();
+    runtime = undefined;
+    restoreStdout?.();
+    restoreStdout = undefined;
     if (handled.result !== undefined) {
       printResult(handled.result, json);
     }
     return handled.exitCode ?? exitCodeFromResult(handled.result);
   } finally {
-    await runtime.close();
+    if (runtime) {
+      await runtime.close();
+    }
+    restoreStdout?.();
   }
 }
 
 async function dispatchCommand(
   runtime: LinceiRuntime,
   args: string[],
+  context: { json?: boolean } = {},
 ): Promise<CommandHandlerResult> {
   const [group, command, ...rest] = args;
   if (isLegacyCommand(group)) {
@@ -78,6 +91,7 @@ async function dispatchCommand(
       runtime,
       group,
       [command, ...rest].filter((arg): arg is string => Boolean(arg)),
+      context,
     );
   }
   const key = command ? `${group} ${command}` : group;
@@ -90,11 +104,17 @@ async function dispatchCommand(
         maxBacktestWorkers:
           numericArgValue(rest, '--max-backtest-workers') ?? 1,
         semanticEvidenceLimit: numericArgValue(rest, '--semantic-limit'),
+        stepTimeoutMs: numericArgValue(rest, '--step-timeout-ms'),
+        onProgress: (event) => printCapitalProgress(event, context.json),
       };
       return {
         result: await runtime.capitalEvidenceSliceService.run(options),
       };
     }
+    case 'capital triage':
+      return {
+        result: buildCapitalTriage(await runtime.statusService.getStatus()),
+      };
     case 'capital status':
     case 'status':
       return { result: await runtime.statusService.getStatus() };
@@ -173,6 +193,10 @@ async function dispatchCommand(
             noStaticMl:
               fullBacktestArgs.includes('--no-static-ml') ||
               !fullBacktestArgs.includes('--with-static-ml'),
+            backtestTimeoutMs: numericArgValue(
+              fullBacktestArgs,
+              '--backtest-timeout-ms',
+            ),
           }),
         {
           isBlocked: isFullBacktestBlocked,
@@ -335,56 +359,93 @@ async function dispatchLegacyCommand(
   runtime: LinceiRuntime,
   command: string,
   args: string[],
+  context: { json?: boolean } = {},
 ): Promise<CommandHandlerResult> {
   switch (command) {
     case 'build-hypothesis-registry':
-      return dispatchCommand(runtime, ['research', 'corpus', ...args]);
+      return dispatchCommand(runtime, ['research', 'corpus', ...args], context);
     case 'run-selected-run-bias-check':
-      return dispatchCommand(runtime, [
-        'research',
-        'selected-run-bias',
-        ...args,
-      ]);
+      return dispatchCommand(
+        runtime,
+        ['research', 'selected-run-bias', ...args],
+        context,
+      );
     case 'ingest-semantic-evidence':
-      return dispatchCommand(runtime, ['data', 'semantic-evidence', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['data', 'semantic-evidence', ...args],
+        context,
+      );
     case 'prepare-lean-local-data':
-      return dispatchCommand(runtime, ['data', 'prepare-lean', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['data', 'prepare-lean', ...args],
+        context,
+      );
     case 'run-alpha-cycle':
-      return dispatchCommand(runtime, ['alpha', 'run', ...args]);
+      return dispatchCommand(runtime, ['alpha', 'run', ...args], context);
     case 'train-ml-baseline':
-      return dispatchCommand(runtime, ['ml', 'train-baseline', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['ml', 'train-baseline', ...args],
+        context,
+      );
     case 'download-external-baselines':
-      return dispatchCommand(runtime, [
-        'ml',
-        'download-external-baselines',
-        ...args,
-      ]);
+      return dispatchCommand(
+        runtime,
+        ['ml', 'download-external-baselines', ...args],
+        context,
+      );
     case 'lean-backtest':
-      return dispatchCommand(runtime, ['lean', 'backtest', ...args]);
+      return dispatchCommand(runtime, ['lean', 'backtest', ...args], context);
     case 'run-full-backtest':
-      return dispatchCommand(runtime, ['lean', 'full-backtest', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['lean', 'full-backtest', ...args],
+        context,
+      );
     case 'import-lean-run':
-      return dispatchCommand(runtime, ['lean', 'import', ...args]);
+      return dispatchCommand(runtime, ['lean', 'import', ...args], context);
     case 'qc-cloud-backtest':
-      return dispatchCommand(runtime, ['qc', 'cloud-backtest', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['qc', 'cloud-backtest', ...args],
+        context,
+      );
     case 'import-cloud-backtest':
-      return dispatchCommand(runtime, ['qc', 'import-backtest', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['qc', 'import-backtest', ...args],
+        context,
+      );
     case 'list-cloud-projects':
-      return dispatchCommand(runtime, ['qc', 'list-projects', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['qc', 'list-projects', ...args],
+        context,
+      );
     case 'list-cloud-backtests':
-      return dispatchCommand(runtime, ['qc', 'list-backtests', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['qc', 'list-backtests', ...args],
+        context,
+      );
     case 'qc-object-store-set':
-      return dispatchCommand(runtime, ['qc', 'object-store-set', ...args]);
+      return dispatchCommand(
+        runtime,
+        ['qc', 'object-store-set', ...args],
+        context,
+      );
     case 'run-paper-cycle':
-      return dispatchCommand(runtime, ['paper', 'run', ...args]);
+      return dispatchCommand(runtime, ['paper', 'run', ...args], context);
     case 'run-paper-replay':
-      return dispatchCommand(runtime, ['paper', 'replay', ...args]);
+      return dispatchCommand(runtime, ['paper', 'replay', ...args], context);
     case 'run-live-shadow':
-      return dispatchCommand(runtime, ['shadow', 'run', ...args]);
+      return dispatchCommand(runtime, ['shadow', 'run', ...args], context);
     case 'run-learning-loop':
-      return dispatchCommand(runtime, ['learning', 'run', ...args]);
+      return dispatchCommand(runtime, ['learning', 'run', ...args], context);
     case 'live-preflight':
-      return dispatchCommand(runtime, ['preflight', 'run', ...args]);
+      return dispatchCommand(runtime, ['preflight', 'run', ...args], context);
     case 'live-pilot-10usd':
       return {
         result: await runtime.orchestrator.runLivePilot10Usd(
@@ -408,6 +469,43 @@ async function dispatchLegacyCommand(
 
 function printResult(result: unknown, _json: boolean): void {
   console.log(JSON.stringify(result, null, 2));
+}
+
+function redirectStdoutToStderr(): () => void {
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void,
+  ): boolean => {
+    if (typeof encodingOrCallback === 'function') {
+      return process.stderr.write(chunk, encodingOrCallback);
+    }
+    return process.stderr.write(chunk, encodingOrCallback, callback);
+  }) as typeof process.stdout.write;
+  return () => {
+    process.stdout.write = originalWrite;
+  };
+}
+
+function printCapitalProgress(
+  event: CapitalEvidenceProgressEvent,
+  json = false,
+): void {
+  if (json) {
+    console.error(
+      JSON.stringify({
+        type: 'capital-progress',
+        ...event,
+      }),
+    );
+    return;
+  }
+  const suffix =
+    event.type === 'completed'
+      ? `: ${event.status}${event.blockers?.length ? ` (${event.blockers.join('; ')})` : ''}`
+      : '';
+  console.error(`[capital] ${event.type} ${event.key}${suffix}`);
 }
 
 function exitCodeFromResult(result: unknown): number {
@@ -499,7 +597,8 @@ function isFullBacktestBlocked(message: string): boolean {
     message.includes('Paid local QC data download is disabled') ||
     message.includes('Stooq CSV download requires STOOQ_API_KEY') ||
     message.includes('Docker is unavailable to the current process') ||
-    message.includes('Missing lean.json')
+    message.includes('Missing lean.json') ||
+    message.includes('LEAN backtest process timed out')
   );
 }
 
@@ -515,10 +614,12 @@ function helpText(): string {
 
 Usage:
   bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --json
+  bun --cwd=backend run lincei -- capital triage --json
   bun --cwd=backend run lincei -- capital status --json
 
 Core commands:
   capital run                         Run the capital evidence vertical slice
+  capital triage                      Show one next safe broker-excluded action
   capital status                      Show V1 capital evidence status
   research corpus                     Ingest Alpha Architect research corpus
   research selected-run-bias          Check retained variant evidence
@@ -540,6 +641,6 @@ Legacy script command names remain accepted during migration.`;
 
 if (require.main === module) {
   runLinceiCli().then((code) => {
-    process.exitCode = code;
+    process.exit(code);
   });
 }

--- a/backend/src/modules/v1-pilot/alpha/current-alpha-target.service.spec.ts
+++ b/backend/src/modules/v1-pilot/alpha/current-alpha-target.service.spec.ts
@@ -1,0 +1,125 @@
+import { CurrentAlphaTargetService } from './current-alpha-target.service';
+
+describe('CurrentAlphaTargetService', () => {
+  it('creates a long-only current target snapshot from latest numeric alpha', async () => {
+    const targetRepository = {
+      create: jest.fn((record) => record),
+      upsert: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new CurrentAlphaTargetService(
+      {
+        find: jest.fn().mockResolvedValue([
+          alphaDecision({
+            id: 'numeric-qqq',
+            symbol: 'QQQ',
+            expectedReturnBps: 90,
+            confidence: 0.6,
+          }),
+          alphaDecision({
+            id: 'numeric-spy',
+            symbol: 'SPY',
+            expectedReturnBps: 70,
+            confidence: 0.4,
+          }),
+          alphaDecision({
+            id: 'numeric-down',
+            symbol: 'TLT',
+            direction: 'down',
+            expectedReturnBps: 80,
+            confidence: 0.8,
+          }),
+        ]),
+      } as never,
+      targetRepository as never,
+    );
+
+    const snapshot = await service.ensureCurrentTargetSnapshot({
+      runId: 'qc-import-test',
+      parameters: { 'alpha-mode': 'numeric-only' },
+    } as never);
+
+    expect(snapshot.id).toMatch(
+      /^current-alpha-target-qc-import-test-numeric-/,
+    );
+    expect(snapshot.targets).toEqual([
+      expect.objectContaining({
+        symbol: 'QQQ',
+        targetWeight: 0.1,
+        sourceInsightIds: ['numeric-qqq'],
+        riskNotes: expect.arrayContaining([
+          'current_alpha_target',
+          'alpha-source:numeric',
+          'market-data-timestamp:2026-05-28T22:00:00.000Z',
+          'long-only',
+        ]),
+      }),
+      expect.objectContaining({
+        symbol: 'SPY',
+        targetWeight: 0.1,
+        sourceInsightIds: ['numeric-spy'],
+      }),
+    ]);
+    expect(snapshot.grossExposurePct).toBe(0.2);
+    expect(snapshot.maxSingleNamePct).toBe(0.1);
+    expect(targetRepository.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leanRunId: 'qc-import-test',
+        targetHash: expect.stringMatching(/^sha256:/),
+      }),
+      ['id'],
+    );
+  });
+
+  it('blocks when the validated run alpha mode has no orderable decisions', async () => {
+    const service = new CurrentAlphaTargetService(
+      {
+        find: jest.fn().mockResolvedValue([
+          alphaDecision({
+            id: 'meta-flat',
+            source: 'meta',
+            symbol: 'SPY',
+            direction: 'flat',
+            expectedReturnBps: 0,
+            confidence: 0,
+          }),
+        ]),
+      } as never,
+      { create: jest.fn(), upsert: jest.fn() } as never,
+    );
+
+    await expect(
+      service.ensureCurrentTargetSnapshot({
+        runId: 'qc-import-test',
+        parameters: { 'alpha-mode': 'meta-overlay' },
+      } as never),
+    ).rejects.toThrow(
+      'No orderable current meta alpha decisions are available for paper trading.',
+    );
+  });
+});
+
+function alphaDecision(
+  overrides: Partial<{
+    id: string;
+    source: 'numeric' | 'llm' | 'meta';
+    symbol: string;
+    asOf: string;
+    availableAt: string;
+    direction: 'up' | 'down' | 'flat';
+    expectedReturnBps: number;
+    confidence: number;
+    maxPositionPct: number;
+  }>,
+) {
+  return {
+    id: overrides.id ?? 'numeric-spy',
+    source: overrides.source ?? 'numeric',
+    symbol: overrides.symbol ?? 'SPY',
+    asOf: overrides.asOf ?? '2026-05-29T00:21:53.133Z',
+    availableAt: overrides.availableAt ?? '2026-05-28T22:00:00.000Z',
+    direction: overrides.direction ?? 'up',
+    expectedReturnBps: overrides.expectedReturnBps ?? 50,
+    confidence: overrides.confidence ?? 0.5,
+    maxPositionPct: overrides.maxPositionPct ?? 0.35,
+  };
+}

--- a/backend/src/modules/v1-pilot/alpha/current-alpha-target.service.ts
+++ b/backend/src/modules/v1-pilot/alpha/current-alpha-target.service.ts
@@ -1,0 +1,225 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AlphaDecision } from '../../../entities/alpha-decision.entity';
+import { LeanRun } from '../../../entities/lean-run.entity';
+import { PortfolioTargetSnapshot } from '../../../entities/portfolio-target-snapshot.entity';
+import { hashObject } from '../../../shared/hash.util';
+import type { AlphaSource } from '../contracts/v1-pilot.contracts';
+
+const CURRENT_TARGET_MAX_COUNT = 2;
+const CURRENT_TARGET_MAX_SINGLE_WEIGHT = 0.1;
+const CURRENT_TARGET_MAX_GROSS_WEIGHT = 0.25;
+const CURRENT_TARGET_MIN_WEIGHT = 0.005;
+const CONFIDENCE_WEIGHT_SCALE = 0.25;
+
+type OrderableAlphaDecision = AlphaDecision & {
+  availableAt: string;
+  expectedReturnBps: number;
+  maxPositionPct: number;
+};
+
+@Injectable()
+export class CurrentAlphaTargetService {
+  constructor(
+    @InjectRepository(AlphaDecision)
+    private readonly alphaRepository: Repository<AlphaDecision>,
+    @InjectRepository(PortfolioTargetSnapshot)
+    private readonly targetRepository: Repository<PortfolioTargetSnapshot>,
+  ) {}
+
+  async ensureCurrentTargetSnapshot(
+    leanRun: LeanRun,
+  ): Promise<PortfolioTargetSnapshot> {
+    const alphaSource = this.alphaSourceForRun(leanRun);
+    const decisions = await this.latestDecisionsForSource(alphaSource);
+    const selected = this.orderableDecisions(decisions).slice(
+      0,
+      CURRENT_TARGET_MAX_COUNT,
+    );
+
+    if (selected.length === 0) {
+      throw new Error(
+        `No orderable current ${alphaSource} alpha decisions are available for paper trading.`,
+      );
+    }
+
+    const marketDataTimestamp = this.latestTimestamp(
+      selected.map((decision) => decision.availableAt),
+    );
+    const generatedAt = new Date().toISOString();
+    const rawTargets = selected.map((decision) => ({
+      symbol: decision.symbol,
+      targetWeight: this.targetWeight(decision),
+      sourceInsightIds: [decision.id],
+      riskAdjusted: true,
+      riskNotes: [
+        'current_alpha_target',
+        `alpha-source:${alphaSource}`,
+        `alpha-decision:${decision.id}`,
+        `alpha-as-of:${decision.asOf}`,
+        `alpha-available-at:${decision.availableAt}`,
+        `market-data-timestamp:${marketDataTimestamp}`,
+        `linked-lean-run:${leanRun.runId}`,
+        'long-only',
+        'broker-write-disabled',
+      ],
+    }));
+    const targets = this.scaleGrossExposure(rawTargets).filter(
+      (target) => Math.abs(target.targetWeight) >= CURRENT_TARGET_MIN_WEIGHT,
+    );
+    if (targets.length === 0) {
+      throw new Error(
+        `Current ${alphaSource} alpha decisions produced only sub-threshold target weights.`,
+      );
+    }
+
+    const targetHash = hashObject({
+      leanRunId: leanRun.runId,
+      alphaSource,
+      marketDataTimestamp,
+      targets: targets.map((target) => ({
+        symbol: target.symbol,
+        targetWeight: target.targetWeight,
+        sourceInsightIds: target.sourceInsightIds,
+      })),
+    });
+    const id = `current-alpha-target-${leanRun.runId}-${alphaSource}-${this.shortHash(targetHash)}`;
+    const record = this.targetRepository.create({
+      id,
+      leanRunId: leanRun.runId,
+      asOf: generatedAt,
+      targets,
+      ...this.targetExposure(targets),
+      targetHash,
+    });
+    await this.targetRepository.upsert(record, ['id']);
+    return record;
+  }
+
+  isCurrentAlphaTarget(snapshot: PortfolioTargetSnapshot | undefined): boolean {
+    return Boolean(
+      snapshot?.id.startsWith('current-alpha-target-') ||
+        snapshot?.targets.some((target) =>
+          target.riskNotes?.includes('current_alpha_target'),
+        ),
+    );
+  }
+
+  currentTargetMarketDataTimestamp(
+    snapshot: PortfolioTargetSnapshot,
+  ): string | undefined {
+    for (const target of snapshot.targets) {
+      const note = target.riskNotes?.find((entry) =>
+        entry.startsWith('market-data-timestamp:'),
+      );
+      if (note) {
+        return note.slice('market-data-timestamp:'.length);
+      }
+    }
+    return undefined;
+  }
+
+  private async latestDecisionsForSource(
+    source: AlphaSource,
+  ): Promise<AlphaDecision[]> {
+    const candidates = await this.alphaRepository.find({
+      where: { source },
+      order: { asOf: 'DESC', updatedAt: 'DESC' },
+      take: 100,
+    });
+    const latestAsOf = candidates[0]?.asOf;
+    return latestAsOf
+      ? candidates.filter((decision) => decision.asOf === latestAsOf)
+      : [];
+  }
+
+  private orderableDecisions(
+    decisions: AlphaDecision[],
+  ): OrderableAlphaDecision[] {
+    return decisions
+      .filter((decision): decision is OrderableAlphaDecision => {
+        return (
+          decision.direction === 'up' &&
+          Boolean(decision.availableAt) &&
+          Number.isFinite(decision.confidence) &&
+          decision.confidence > 0 &&
+          Number.isFinite(decision.expectedReturnBps) &&
+          Number(decision.expectedReturnBps) > 0 &&
+          Number.isFinite(decision.maxPositionPct) &&
+          Number(decision.maxPositionPct) > 0
+        );
+      })
+      .sort((left, right) => this.alphaScore(right) - this.alphaScore(left));
+  }
+
+  private alphaScore(decision: OrderableAlphaDecision): number {
+    return decision.expectedReturnBps * decision.confidence;
+  }
+
+  private targetWeight(decision: OrderableAlphaDecision): number {
+    return Number(
+      Math.min(
+        decision.maxPositionPct,
+        CURRENT_TARGET_MAX_SINGLE_WEIGHT,
+        decision.confidence * CONFIDENCE_WEIGHT_SCALE,
+      ).toFixed(6),
+    );
+  }
+
+  private scaleGrossExposure<T extends { targetWeight: number }>(targets: T[]) {
+    const gross = targets.reduce(
+      (sum, target) => sum + Math.abs(target.targetWeight),
+      0,
+    );
+    if (gross <= CURRENT_TARGET_MAX_GROSS_WEIGHT) {
+      return targets;
+    }
+    const scale = CURRENT_TARGET_MAX_GROSS_WEIGHT / gross;
+    return targets.map((target) => ({
+      ...target,
+      targetWeight: Number((target.targetWeight * scale).toFixed(6)),
+    }));
+  }
+
+  private targetExposure(targets: { targetWeight: number }[]): {
+    grossExposurePct: number;
+    maxSingleNamePct: number;
+  } {
+    const weights = targets.map((target) => Math.abs(target.targetWeight));
+    return {
+      grossExposurePct: Number(
+        weights.reduce((sum, weight) => sum + weight, 0).toFixed(6),
+      ),
+      maxSingleNamePct: Number(Math.max(0, ...weights).toFixed(6)),
+    };
+  }
+
+  private latestTimestamp(timestamps: string[]): string {
+    const latest = timestamps
+      .map((timestamp) => new Date(timestamp))
+      .filter((date) => Number.isFinite(date.getTime()))
+      .sort((left, right) => right.getTime() - left.getTime())[0];
+    if (!latest) {
+      throw new Error(
+        'Current alpha target generation requires at least one valid alpha availability timestamp.',
+      );
+    }
+    return latest.toISOString();
+  }
+
+  private alphaSourceForRun(leanRun: LeanRun): AlphaSource {
+    const alphaMode = String(leanRun.parameters['alpha-mode'] ?? '');
+    if (alphaMode === 'numeric-only') {
+      return 'numeric';
+    }
+    if (alphaMode === 'llm-only' || alphaMode === 'semantic-llm') {
+      return 'llm';
+    }
+    return 'meta';
+  }
+
+  private shortHash(hash: string): string {
+    return hash.replace(/^sha256:/, '').slice(0, 12);
+  }
+}

--- a/backend/src/modules/v1-pilot/lean/lean-cli.runner.ts
+++ b/backend/src/modules/v1-pilot/lean/lean-cli.runner.ts
@@ -45,6 +45,8 @@ const REQUIRED_ARTIFACTS = [
   'logs.txt',
 ] as const;
 
+const DEFAULT_LEAN_BACKTEST_TIMEOUT_MS = 10 * 60_000;
+
 type LeanDockerMode = 'direct' | 'sg-docker';
 
 export type LeanCliBacktestRequest = {
@@ -63,6 +65,7 @@ export type LeanCliBacktestRequest = {
   allowLeveragedEtf?: boolean;
   allowSummaryHydration?: boolean;
   requireStrategyEvidence?: boolean;
+  timeoutMs?: number;
 };
 
 export type LeanCliBacktestResult = {
@@ -168,6 +171,7 @@ export class LeanCliRunner {
     }
     const { leanBin, processEnv, dockerMode } = this.assertPrerequisites();
     const projectName = request.projectName ?? 'aggressive_llm_momentum';
+    const timeoutMs = this.resolveBacktestTimeoutMs(request.timeoutMs);
     const runId =
       request.runId ??
       `bt-${new Date()
@@ -270,7 +274,13 @@ export class LeanCliRunner {
     let stdout = '';
     let stderr = '';
     try {
-      stdout = this.runLeanCommand(leanBin, args, processEnv, dockerMode);
+      stdout = this.runLeanCommand(
+        leanBin,
+        args,
+        processEnv,
+        dockerMode,
+        timeoutMs,
+      );
     } catch (error) {
       const execError = error as {
         stdout?: string;
@@ -299,11 +309,11 @@ export class LeanCliRunner {
         outputDirectory,
       });
       const latestLog = readLeanLog(matchedBacktestDirectory);
-      const diagnostic = summarizeLeanCliFailure({
-        stdout,
-        stderr,
-        logText: latestLog?.text,
-      });
+      const diagnostic = this.leanFailureDiagnostic(
+        { stdout, stderr, message: execError.message },
+        latestLog?.text,
+        timeoutMs,
+      );
       writeLeanCliFailureDiagnostics({
         outputDirectory,
         runId,
@@ -518,6 +528,7 @@ export class LeanCliRunner {
     args: string[],
     processEnv: NodeJS.ProcessEnv,
     dockerMode: LeanDockerMode,
+    timeoutMs: number,
   ): string {
     if (dockerMode === 'direct') {
       return execFileSync(leanBin, args, {
@@ -525,6 +536,7 @@ export class LeanCliRunner {
         encoding: 'utf8',
         maxBuffer: 32 * 1024 * 1024,
         env: processEnv,
+        timeout: timeoutMs,
       });
     }
 
@@ -536,8 +548,41 @@ export class LeanCliRunner {
         encoding: 'utf8',
         maxBuffer: 32 * 1024 * 1024,
         env: processEnv,
+        timeout: timeoutMs,
       },
     );
+  }
+
+  private resolveBacktestTimeoutMs(requestTimeoutMs?: number): number {
+    const configured = Number(
+      process.env.LEAN_BACKTEST_TIMEOUT_MS ?? DEFAULT_LEAN_BACKTEST_TIMEOUT_MS,
+    );
+    const timeoutMs = requestTimeoutMs ?? configured;
+    return Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? timeoutMs
+      : DEFAULT_LEAN_BACKTEST_TIMEOUT_MS;
+  }
+
+  private leanFailureDiagnostic(
+    error: {
+      stdout?: string;
+      stderr?: string;
+      message?: string;
+    },
+    logText: string | undefined,
+    timeoutMs: number,
+  ): string {
+    if (
+      error.message?.includes('ETIMEDOUT') ||
+      error.message?.includes('timed out')
+    ) {
+      return `LEAN backtest process timed out after ${timeoutMs} ms.`;
+    }
+    return summarizeLeanCliFailure({
+      stdout: error.stdout ?? '',
+      stderr: error.stderr ?? '',
+      logText,
+    });
   }
 
   private shellCommand(parts: string[]): string {

--- a/backend/src/modules/v1-pilot/live/live-shadow.service.ts
+++ b/backend/src/modules/v1-pilot/live/live-shadow.service.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { LiveShadowRecord } from '../../../entities/live-shadow-record.entity';
-import { PortfolioTargetSnapshot } from '../../../entities/portfolio-target-snapshot.entity';
 import { hashObject } from '../../../shared/hash.util';
+import { CurrentAlphaTargetService } from '../alpha/current-alpha-target.service';
 import { assessLeanRunArtifacts } from '../lean/lean-run-acceptance';
 import { LeanRunImportService } from '../lean/lean-run-import.service';
 
@@ -11,8 +11,7 @@ import { LeanRunImportService } from '../lean/lean-run-import.service';
 export class LiveShadowService {
   constructor(
     private readonly leanRunImportService: LeanRunImportService,
-    @InjectRepository(PortfolioTargetSnapshot)
-    private readonly targetRepository: Repository<PortfolioTargetSnapshot>,
+    private readonly currentAlphaTargetService: CurrentAlphaTargetService,
     @InjectRepository(LiveShadowRecord)
     private readonly liveShadowRepository: Repository<LiveShadowRecord>,
   ) {}
@@ -37,13 +36,7 @@ export class LiveShadowService {
     }
 
     const snapshot = latestRun
-      ? (
-          await this.targetRepository.find({
-            where: { leanRunId: latestRun.runId },
-            order: { asOf: 'DESC' },
-            take: 1,
-          })
-        )[0]
+      ? await this.currentTargetSnapshot(latestRun, blockers)
       : undefined;
     if (!snapshot?.targets.length) {
       blockers.push(
@@ -109,6 +102,26 @@ export class LiveShadowService {
       take: 1,
     });
     return records[0] ?? null;
+  }
+
+  private async currentTargetSnapshot(
+    latestRun: NonNullable<
+      Awaited<ReturnType<LeanRunImportService['getLatestStrategyRun']>>
+    >,
+    blockers: string[],
+  ) {
+    try {
+      return await this.currentAlphaTargetService.ensureCurrentTargetSnapshot(
+        latestRun,
+      );
+    } catch (error) {
+      blockers.push(
+        error instanceof Error
+          ? error.message
+          : 'Current alpha target generation failed.',
+      );
+      return undefined;
+    }
   }
 
   private isCurrentTargetSnapshot(

--- a/backend/src/modules/v1-pilot/paper/lean-paper-bridge.service.spec.ts
+++ b/backend/src/modules/v1-pilot/paper/lean-paper-bridge.service.spec.ts
@@ -40,6 +40,15 @@ describe('LeanPaperBridgeService', () => {
         }),
       } as never,
       {
+        ensureCurrentTargetSnapshot: jest.fn().mockResolvedValue({
+          id: 11,
+          leanRunId: tempDir.split('/').pop(),
+          targets: [{ symbol: 'SPY', targetWeight: 0.35 }],
+        }),
+        currentTargetMarketDataTimestamp: jest.fn(),
+        isCurrentAlphaTarget: jest.fn().mockReturnValue(false),
+      } as never,
+      {
         find: jest.fn().mockResolvedValue([
           {
             id: 11,
@@ -130,6 +139,11 @@ describe('LeanPaperBridgeService', () => {
         }),
       } as never,
       {
+        ensureCurrentTargetSnapshot: jest.fn(),
+        currentTargetMarketDataTimestamp: jest.fn(),
+        isCurrentAlphaTarget: jest.fn().mockReturnValue(false),
+      } as never,
+      {
         find: jest.fn().mockResolvedValue([
           {
             id: 11,
@@ -179,6 +193,120 @@ describe('LeanPaperBridgeService', () => {
             symbol: 'VRT XBX55P02OU3P',
             notional: 4000,
             targetPositionPct: 40,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('builds a current paper proposal from current alpha targets', async () => {
+    const filledPlan = {
+      id: 13,
+      status: 'filled',
+      reconciliation: { status: 'pending' },
+    } as PaperOrderPlan;
+    const reconciledPlan = {
+      ...filledPlan,
+      status: 'reconciled',
+      reconciliation: { status: 'matched' },
+    } as PaperOrderPlan;
+    const controlPlaneService = {
+      listBudgetEnvelopes: jest
+        .fn()
+        .mockResolvedValue([{ id: 1, name: 'V1 LEAN Paper Budget (ETF)' }]),
+      getPaperAccountState: jest.fn().mockResolvedValue({
+        id: 2,
+        budgetEnvelopeId: 1,
+        currency: 'USD',
+        cash: 10_000,
+        equity: 10_000,
+        grossExposurePct: 0,
+        positions: [],
+      }),
+      listBrokerSnapshots: jest.fn().mockResolvedValue([{ id: 3 }]),
+      createResearchRun: jest.fn().mockResolvedValue({ id: 4 }),
+      createProposal: jest.fn().mockResolvedValue({ id: 5 }),
+      evaluateProposal: jest.fn().mockResolvedValue({ decision: 'REVIEW' }),
+      listPaperAccountEvents: jest
+        .fn()
+        .mockResolvedValue([{ eventHash: 'event-hash' }]),
+      createOrderPlanApproval: jest.fn().mockResolvedValue({ id: 6 }),
+      paperExecuteProposal: jest.fn().mockResolvedValue(filledPlan),
+      reconcilePaperOrderPlan: jest.fn().mockResolvedValue(reconciledPlan),
+    };
+    const service = new LeanPaperBridgeService(
+      controlPlaneService as never,
+      {
+        getLatestStrategyRun: jest.fn().mockResolvedValue({
+          runId: tempDir.split('/').pop(),
+          status: 'passed',
+          resultDirectory: tempDir,
+          startedAt: new Date('2026-05-25T07:10:18.000Z'),
+          completedAt: new Date('2026-05-25T07:12:56.000Z'),
+          statistics: JSON.parse(
+            readFileSync(join(tempDir, 'statistics.json'), 'utf8'),
+          ),
+          configHash: 'config-hash',
+        }),
+      } as never,
+      {
+        ensureCurrentTargetSnapshot: jest.fn().mockResolvedValue({
+          id: 'current-alpha-target-test',
+          leanRunId: tempDir.split('/').pop(),
+          asOf: '2026-05-29T00:40:00.000Z',
+          targetHash: 'target-hash',
+          targets: [
+            {
+              symbol: 'QQQ',
+              targetWeight: 0.1,
+              riskNotes: [
+                'current_alpha_target',
+                'market-data-timestamp:2026-05-28T22:00:00.000Z',
+              ],
+            },
+            {
+              symbol: 'SPY',
+              targetWeight: 0.08,
+              riskNotes: [
+                'current_alpha_target',
+                'market-data-timestamp:2026-05-28T22:00:00.000Z',
+              ],
+            },
+          ],
+        }),
+        currentTargetMarketDataTimestamp: jest
+          .fn()
+          .mockReturnValue('2026-05-28T22:00:00.000Z'),
+        isCurrentAlphaTarget: jest.fn().mockReturnValue(true),
+      } as never,
+      {
+        find: jest.fn(),
+      } as never,
+      {
+        find: jest.fn().mockResolvedValue([]),
+      } as never,
+    );
+
+    const result = await service.runPaperCycle();
+
+    expect(result).toBe(reconciledPlan);
+    expect(controlPlaneService.createProposal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketDataTimestamp: '2026-05-28T22:00:00.000Z',
+        thesis: expect.stringContaining('Current paper cycle'),
+        evidenceRefs: expect.not.arrayContaining([
+          'paper-replay:historical-target',
+        ]),
+        orders: [
+          expect.objectContaining({
+            symbol: 'QQQ',
+            notional: 1000,
+            targetPositionPct: 10,
+          }),
+          expect.objectContaining({
+            symbol: 'SPY',
+            notional: 800,
+            targetPositionPct: 8,
           }),
         ],
       }),

--- a/backend/src/modules/v1-pilot/paper/lean-paper-bridge.service.ts
+++ b/backend/src/modules/v1-pilot/paper/lean-paper-bridge.service.ts
@@ -11,6 +11,7 @@ import { PaperOrderPlan } from '../../../entities/paper-order-plan.entity';
 import { LeanRunImportService } from '../lean/lean-run-import.service';
 import type { PortfolioTargetItemContract } from '../contracts/v1-pilot.contracts';
 import { assessLeanRunArtifacts } from '../lean/lean-run-acceptance';
+import { CurrentAlphaTargetService } from '../alpha/current-alpha-target.service';
 
 type PaperBridgeMode = 'current-paper-cycle' | 'historical-target-replay';
 
@@ -25,6 +26,7 @@ export class LeanPaperBridgeService {
   constructor(
     private readonly controlPlaneService: ControlPlaneService,
     private readonly leanRunImportService: LeanRunImportService,
+    private readonly currentAlphaTargetService: CurrentAlphaTargetService,
     @InjectRepository(PortfolioTargetSnapshot)
     private readonly targetRepository: Repository<PortfolioTargetSnapshot>,
     @InjectRepository(PaperOrderPlan)
@@ -66,12 +68,12 @@ export class LeanPaperBridgeService {
       );
     }
 
-    const target = await this.targetRepository.find({
-      where: { leanRunId: latestRun.runId },
-      order: { asOf: 'DESC' },
-      take: 1,
-    });
-    const snapshot = target[0];
+    const snapshot =
+      mode === 'current-paper-cycle'
+        ? await this.currentAlphaTargetService.ensureCurrentTargetSnapshot(
+            latestRun,
+          )
+        : await this.latestHistoricalTargetSnapshot(latestRun.runId);
     if (!snapshot?.targets.length) {
       throw new Error('Latest LEAN run has no portfolio targets.');
     }
@@ -106,29 +108,56 @@ export class LeanPaperBridgeService {
       scopedIdempotencyKey,
     );
     await this.ensureBrokerSnapshot(paperAccount.id);
+    const now = new Date().toISOString();
+    const marketDataTimestamp =
+      mode === 'historical-target-replay'
+        ? now
+        : (this.currentAlphaTargetService.currentTargetMarketDataTimestamp(
+            snapshot,
+          ) ?? snapshot.asOf);
     const researchRun = await this.controlPlaneService.createResearchRun({
       budgetEnvelopeId: budget.id,
       objective:
         mode === 'historical-target-replay'
           ? 'V1 LEAN historical target paper replay'
-          : 'V1 LEAN portfolio target paper cycle',
+          : 'V1 current alpha target paper cycle',
       strategyFamily: 'aggressive_llm_momentum',
       hypothesis:
         mode === 'historical-target-replay'
           ? 'Historical LEAN targets can exercise the paper execution plumbing without becoming broker-write pre-trade risk check artifacts.'
-          : 'Imported LEAN targets can execute in paper mode.',
+          : 'Fresh alpha decisions can create current-market paper targets without becoming broker writes.',
       datasetRefs: [
         {
-          id: 'lean-run',
-          source: 'lean',
-          windowStart: latestRun.startedAt.toISOString(),
-          windowEnd: latestRun.completedAt.toISOString(),
-          availabilityTimestamp: latestRun.completedAt.toISOString(),
-          marketDataTimestamp: latestRun.completedAt.toISOString(),
+          id:
+            mode === 'historical-target-replay'
+              ? 'lean-run'
+              : 'current-alpha-target',
+          source:
+            mode === 'historical-target-replay'
+              ? 'lean'
+              : 'alpha-decision-ledger',
+          windowStart:
+            mode === 'historical-target-replay'
+              ? latestRun.startedAt.toISOString()
+              : marketDataTimestamp,
+          windowEnd:
+            mode === 'historical-target-replay'
+              ? latestRun.completedAt.toISOString()
+              : marketDataTimestamp,
+          availabilityTimestamp:
+            mode === 'historical-target-replay'
+              ? latestRun.completedAt.toISOString()
+              : snapshot.asOf,
+          marketDataTimestamp,
         },
       ],
       featureRefs: ['v1-feature-snapshot'],
-      timestampLagRules: ['Use LEAN run completion timestamp only.'],
+      timestampLagRules:
+        mode === 'historical-target-replay'
+          ? ['Use LEAN run completion timestamp only.']
+          : [
+              'Use alpha decision availableAt as marketDataTimestamp; portfolio target asOf is generation time only.',
+            ],
       noLookaheadChecked: true,
       benchmark: 'SPY',
       costModel: 'paper-sim-v1',
@@ -148,14 +177,13 @@ export class LeanPaperBridgeService {
               'Paper replay uses historical target timestamps and is not a current-market artifact.',
               'The live-preflight legacy command must ignore paper-replay evidence refs.',
             ]
-          : ['Paper bridge depends on LEAN target import.'],
+          : [
+              'Current paper cycle depends on fresh alpha decisions and remains broker-write disabled.',
+              'Latest LEAN/Cloud run is validation evidence, not the source of current target timestamps.',
+            ],
     });
 
     const orders = this.buildOrders(snapshot.targets);
-    const now = new Date().toISOString();
-    // Historical replay must carry an explicit paper-replay evidence ref; the live-preflight legacy command rejects it so a fresh replay timestamp cannot masquerade as a current-market artifact.
-    const marketDataTimestamp =
-      mode === 'historical-target-replay' ? now : snapshot.asOf;
     const proposal = await this.controlPlaneService.createProposal({
       budgetEnvelopeId: budget.id,
       researchRunId: researchRun.id,
@@ -174,7 +202,7 @@ export class LeanPaperBridgeService {
       thesis:
         mode === 'historical-target-replay'
           ? `Historical paper replay from LEAN targets as of ${snapshot.asOf}; not broker-write pre-trade risk check evidence.`
-          : 'Paper cycle from latest LEAN portfolio targets.',
+          : `Current paper cycle from alpha-derived targets generated at ${snapshot.asOf}.`,
       evidenceRefs: [
         leanRunEvidenceRef,
         targetEvidenceRef,
@@ -225,6 +253,20 @@ export class LeanPaperBridgeService {
     return this.controlPlaneService.reconcilePaperOrderPlan(plan.id, {
       notes: ['Auto-reconciled by V1 LEAN paper bridge.'],
     });
+  }
+
+  private async latestHistoricalTargetSnapshot(
+    leanRunId: string,
+  ): Promise<PortfolioTargetSnapshot | undefined> {
+    const candidates = await this.targetRepository.find({
+      where: { leanRunId },
+      order: { asOf: 'DESC' },
+      take: 20,
+    });
+    return candidates.find(
+      (snapshot) =>
+        !this.currentAlphaTargetService.isCurrentAlphaTarget(snapshot),
+    );
   }
 
   private async ensureBudget() {

--- a/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts
+++ b/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts
@@ -2,7 +2,11 @@ import { Repository } from 'typeorm';
 import { AlphaDecision } from '../../../entities/alpha-decision.entity';
 import { ResearchJobRecord } from '../../../entities/research-job-record.entity';
 import { V1PilotOrchestratorService } from '../v1-pilot-orchestrator.service';
-import { CapitalEvidenceSliceService } from './capital-evidence-slice.service';
+import {
+  CapitalEvidenceProgressEvent,
+  CapitalEvidenceSliceService,
+  DEFAULT_CAPITAL_UNIVERSE,
+} from './capital-evidence-slice.service';
 import { ResearchFactoryService } from './research-factory.service';
 
 describe('CapitalEvidenceSliceService', () => {
@@ -46,7 +50,8 @@ describe('CapitalEvidenceSliceService', () => {
     expect(savedJobs.every((job) => job.jobType === 'ablation')).toBe(true);
     expect(result.brokerWriteCandidateStatus.status).toBe('blocked');
     expect(JSON.stringify(result.promotionDecision)).toContain('blocked');
-    expect(result.universe).toContain('SMH');
+    expect(result.universe).toEqual([...DEFAULT_CAPITAL_UNIVERSE]);
+    expect(process.env.V1_UNIVERSE_SYMBOLS).toBe(originalUniverseSymbols);
   });
 
   it('runs and reports the same explicit universe override', async () => {
@@ -72,9 +77,56 @@ describe('CapitalEvidenceSliceService', () => {
     expect(orchestrator.prepareLeanLocalData).toHaveBeenCalled();
     expect(process.env.V1_UNIVERSE_SYMBOLS).toBe(originalUniverseSymbols);
   });
+
+  it('records a blocked step and progress events when a step times out', async () => {
+    const events: CapitalEvidenceProgressEvent[] = [];
+    const orchestrator = mockOrchestrator({
+      buildHypothesisRegistry: jest.fn(() => new Promise(() => undefined)),
+    });
+    const service = new CapitalEvidenceSliceService(
+      orchestrator,
+      mockResearchFactory(),
+      {
+        create: (record: ResearchJobRecord) => record,
+        save: async (record: ResearchJobRecord) => record,
+      } as unknown as Repository<ResearchJobRecord>,
+      {
+        find: async () => [],
+      } as unknown as Repository<AlphaDecision>,
+    );
+
+    const result = await service.run({
+      maxBacktestWorkers: 1,
+      stepTimeoutMs: 5,
+      onProgress: (event) => events.push(event),
+    });
+
+    const researchCorpus = result.steps.find(
+      (step) => step.key === 'research-corpus',
+    );
+    expect(researchCorpus?.status).toBe('blocked');
+    expect(researchCorpus?.blockers).toContain(
+      'Research corpus ingest timed out after 5 ms.',
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'started',
+          key: 'research-corpus',
+        }),
+        expect.objectContaining({
+          type: 'completed',
+          key: 'research-corpus',
+          status: 'blocked',
+        }),
+      ]),
+    );
+  });
 });
 
-function mockOrchestrator(): V1PilotOrchestratorService {
+function mockOrchestrator(
+  overrides: Partial<Record<keyof V1PilotOrchestratorService, unknown>> = {},
+): V1PilotOrchestratorService {
   return {
     buildHypothesisRegistry: jest.fn(async () => ({
       status: 'completed',
@@ -123,6 +175,7 @@ function mockOrchestrator(): V1PilotOrchestratorService {
       status: 'blocked',
       blockers: ['Broker read-only snapshot is missing.'],
     })),
+    ...overrides,
   } as unknown as V1PilotOrchestratorService;
 }
 

--- a/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.ts
+++ b/backend/src/modules/v1-pilot/research/capital-evidence-slice.service.ts
@@ -19,6 +19,9 @@ import { ResearchFactoryService } from './research-factory.service';
 export const DEFAULT_CAPITAL_HYPOTHESIS_ID =
   'research-hypothesis-alphaarchitect-08-rethinking-trend-following-optimal-regime-dependent-allocation';
 
+export const DEFAULT_CAPITAL_UNIVERSE = ['SPY', 'QQQ', 'TLT', 'IEF'] as const;
+export const DEFAULT_CAPITAL_STEP_TIMEOUT_MS = 5 * 60_000;
+
 export const DEFAULT_CAPITAL_VARIANTS = [
   {
     id: 'trend-regime-numeric-v1',
@@ -49,6 +52,8 @@ export interface CapitalEvidenceRunOptions {
   universe?: string[];
   maxBacktestWorkers?: number;
   semanticEvidenceLimit?: number;
+  stepTimeoutMs?: number;
+  onProgress?: (event: CapitalEvidenceProgressEvent) => void;
 }
 
 export interface CapitalEvidenceStep<T = unknown> {
@@ -60,6 +65,15 @@ export interface CapitalEvidenceStep<T = unknown> {
   blockers: string[];
   evidenceRefs: string[];
   output?: T;
+}
+
+export interface CapitalEvidenceProgressEvent {
+  type: 'started' | 'completed';
+  key: string;
+  label: string;
+  at: string;
+  status?: CapitalEvidenceStepStatus;
+  blockers?: string[];
 }
 
 export interface CapitalVariantOutcome {
@@ -81,6 +95,7 @@ export interface CapitalEvidenceSliceResult {
   hypothesisId: string;
   universe: string[];
   maxBacktestWorkers: number;
+  stepTimeoutMs: number;
   variants: CapitalVariantOutcome[];
   variantSummary: {
     passed: number;
@@ -113,8 +128,11 @@ export class CapitalEvidenceSliceService {
   async run(
     options: CapitalEvidenceRunOptions = {},
   ): Promise<CapitalEvidenceSliceResult> {
-    return this.withUniverseOverride(options.universe, async () =>
-      this.runWithResolvedUniverse(options),
+    const universe = options.universe?.length
+      ? options.universe
+      : [...DEFAULT_CAPITAL_UNIVERSE];
+    return this.withUniverseOverride(universe, async () =>
+      this.runWithResolvedUniverse({ ...options, universe }),
     );
   }
 
@@ -127,13 +145,22 @@ export class CapitalEvidenceSliceService {
     const universeSelection = resolveUniverseSelection();
     const universe = universeSelection.activeSymbols;
     const maxBacktestWorkers = options.maxBacktestWorkers ?? 1;
+    const stepTimeoutMs =
+      options.stepTimeoutMs ?? DEFAULT_CAPITAL_STEP_TIMEOUT_MS;
+    const stepOptions = {
+      timeoutMs: stepTimeoutMs,
+      onProgress: options.onProgress,
+    };
     const steps: CapitalEvidenceStep[] = [];
     const blockers: string[] = [];
     let promotionDecision: unknown;
 
     steps.push(
-      await this.runStep('research-corpus', 'Research corpus ingest', () =>
-        this.orchestrator.buildHypothesisRegistry({}),
+      await this.runStep(
+        'research-corpus',
+        'Research corpus ingest',
+        () => this.orchestrator.buildHypothesisRegistry({}),
+        stepOptions,
       ),
     );
 
@@ -146,6 +173,7 @@ export class CapitalEvidenceSliceService {
             source: 'hf-fomc-statements-minutes',
             limit: options.semanticEvidenceLimit ?? 80,
           }),
+        stepOptions,
       ),
     );
 
@@ -156,12 +184,16 @@ export class CapitalEvidenceSliceService {
         this.orchestrator.prepareLeanLocalData({
           ingestUniverseBars: true,
         }),
+      stepOptions,
     );
     steps.push(pointInTimeData);
 
     const alphaStartedAt = new Date();
-    const alphaStep = await this.runStep('alpha-cycle', 'Alpha cycle', () =>
-      this.orchestrator.runAlphaCycle(),
+    const alphaStep = await this.runStep(
+      'alpha-cycle',
+      'Alpha cycle',
+      () => this.orchestrator.runAlphaCycle(),
+      stepOptions,
     );
     steps.push(alphaStep);
 
@@ -185,7 +217,9 @@ export class CapitalEvidenceSliceService {
                 ingestUniverseBars: false,
                 noStaticMeta: true,
                 noStaticMl: true,
+                backtestTimeoutMs: stepTimeoutMs,
               }),
+            stepOptions,
           )
         : this.skippedStep('lean-validation', 'Local LEAN validation attempt', [
             'Skipped because point-in-time market data or local LEAN data preparation is blocked.',
@@ -197,6 +231,7 @@ export class CapitalEvidenceSliceService {
         'quantconnect-cloud-credential-check',
         'QuantConnect Cloud credential and project access check',
         () => this.orchestrator.listQuantConnectCloudProjects({ limit: 5 }),
+        stepOptions,
       ),
     );
 
@@ -209,18 +244,25 @@ export class CapitalEvidenceSliceService {
             hypothesisId,
             minVariantCount: DEFAULT_CAPITAL_VARIANTS.length,
           }),
+        stepOptions,
       ),
     );
 
     steps.push(
-      await this.runStep('paper-cycle', 'Current paper trading cycle', () =>
-        this.orchestrator.runPaperCycle(),
+      await this.runStep(
+        'paper-cycle',
+        'Current paper trading cycle',
+        () => this.orchestrator.runPaperCycle(),
+        stepOptions,
       ),
     );
 
     steps.push(
-      await this.runStep('live-shadow', 'Shadow trading record', () =>
-        this.orchestrator.runLiveShadow(),
+      await this.runStep(
+        'live-shadow',
+        'Shadow trading record',
+        () => this.orchestrator.runLiveShadow(),
+        stepOptions,
       ),
     );
 
@@ -228,6 +270,7 @@ export class CapitalEvidenceSliceService {
       'learning-loop',
       'Outcome labeling and promotion decision',
       () => this.orchestrator.runLearningLoop(),
+      stepOptions,
     );
     steps.push(learningStep);
     promotionDecision =
@@ -243,6 +286,7 @@ export class CapitalEvidenceSliceService {
         'broker-write-preflight',
         'Broker-write pre-trade risk check',
         () => this.orchestrator.runLivePreflight(),
+        stepOptions,
       ),
     );
 
@@ -265,6 +309,7 @@ export class CapitalEvidenceSliceService {
       hypothesisId,
       universe,
       maxBacktestWorkers,
+      stepTimeoutMs,
       variants,
       variantSummary,
       steps,
@@ -437,12 +482,26 @@ export class CapitalEvidenceSliceService {
     key: string,
     label: string,
     run: () => Promise<T>,
+    options: {
+      timeoutMs: number;
+      onProgress?: (event: CapitalEvidenceProgressEvent) => void;
+    },
   ): Promise<CapitalEvidenceStep<T>> {
     const startedAt = new Date().toISOString();
+    options.onProgress?.({
+      type: 'started',
+      key,
+      label,
+      at: startedAt,
+    });
     try {
-      const output = await run();
+      const output = await this.withStepTimeout(
+        Promise.resolve().then(run),
+        options.timeoutMs,
+        label,
+      );
       const blockers = this.outputBlockers(output);
-      return {
+      const step = {
         key,
         label,
         status: blockers.length ? 'blocked' : 'passed',
@@ -451,9 +510,18 @@ export class CapitalEvidenceSliceService {
         blockers,
         evidenceRefs: this.outputEvidenceRefs(output),
         output,
-      };
+      } satisfies CapitalEvidenceStep<T>;
+      options.onProgress?.({
+        type: 'completed',
+        key,
+        label,
+        at: step.completedAt,
+        status: step.status,
+        blockers: step.blockers,
+      });
+      return step;
     } catch (error) {
-      return {
+      const step = {
         key,
         label,
         status: 'blocked',
@@ -461,7 +529,41 @@ export class CapitalEvidenceSliceService {
         completedAt: new Date().toISOString(),
         blockers: [this.errorMessage(error)],
         evidenceRefs: [],
-      };
+      } satisfies CapitalEvidenceStep<T>;
+      options.onProgress?.({
+        type: 'completed',
+        key,
+        label,
+        at: step.completedAt,
+        status: step.status,
+        blockers: step.blockers,
+      });
+      return step;
+    }
+  }
+
+  private async withStepTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    label: string,
+  ): Promise<T> {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return promise;
+    }
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<T>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error(`${label} timed out after ${timeoutMs} ms.`));
+          }, timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
     }
   }
 
@@ -640,10 +742,17 @@ export class CapitalEvidenceSliceService {
   }
 
   private runId(startedAt: Date, options: CapitalEvidenceRunOptions): string {
+    const runIdInput = {
+      hypothesisId: options.hypothesisId,
+      universe: options.universe,
+      maxBacktestWorkers: options.maxBacktestWorkers,
+      semanticEvidenceLimit: options.semanticEvidenceLimit,
+      stepTimeoutMs: options.stepTimeoutMs,
+    };
     return `capital-evidence-${startedAt
       .toISOString()
       .replace(/[-:TZ.]/g, '')
-      .slice(0, 14)}-${this.shortHash(options)}`;
+      .slice(0, 14)}-${this.shortHash(runIdInput)}`;
   }
 
   private shortHash(payload: unknown): string {

--- a/backend/src/modules/v1-pilot/v1-pilot-orchestrator.service.ts
+++ b/backend/src/modules/v1-pilot/v1-pilot-orchestrator.service.ts
@@ -83,6 +83,7 @@ export class V1PilotOrchestratorService {
       validationMode?: string;
       noStaticMeta?: boolean;
       noStaticMl?: boolean;
+      backtestTimeoutMs?: number;
     } = {},
   ): Promise<Record<string, unknown>> {
     const repoRoot = resolve(process.cwd(), '..');
@@ -135,6 +136,7 @@ export class V1PilotOrchestratorService {
       universeSymbols,
       universeProfile: universeSelection.profile,
       requireStrategyEvidence: true,
+      timeoutMs: options.backtestTimeoutMs,
     });
     steps.leanBacktest = leanResult;
     steps.universeSelection = universeSelection;

--- a/backend/src/modules/v1-pilot/v1-pilot.module.ts
+++ b/backend/src/modules/v1-pilot/v1-pilot.module.ts
@@ -27,6 +27,7 @@ import { BrokerOrderStatusRecord } from '../../entities/broker-order-status.enti
 import { ExecutionControlState } from '../../entities/execution-control-state.entity';
 import { ControlPlaneModule } from '../control-plane/control-plane.module';
 import { FeatureSnapshotService } from './alpha/feature-snapshot.service';
+import { CurrentAlphaTargetService } from './alpha/current-alpha-target.service';
 import { LlmEventFeatureService } from './alpha/llm-event-feature.service';
 import { NumericAlphaService } from './alpha/numeric-alpha.service';
 import { LlmAlphaService } from './alpha/llm-alpha.service';
@@ -95,6 +96,7 @@ import { CapitalEvidenceSliceService } from './research/capital-evidence-slice.s
     MlBaselineInferenceService,
     LlmAlphaService,
     MetaAlphaService,
+    CurrentAlphaTargetService,
     LeanLocalSimulatorService,
     LeanDailyDataExportService,
     LeanDataPreparationService,

--- a/backend/src/runtime/create-lincei-runtime.ts
+++ b/backend/src/runtime/create-lincei-runtime.ts
@@ -40,6 +40,7 @@ import { StooqMarketDataService } from '../modules/control-plane/stooq-market-da
 import { ControlPlaneService } from '../modules/control-plane/control-plane.service';
 import { RiskGateService } from '../modules/risk-gate/risk-gate.service';
 import { FeatureSnapshotService } from '../modules/v1-pilot/alpha/feature-snapshot.service';
+import { CurrentAlphaTargetService } from '../modules/v1-pilot/alpha/current-alpha-target.service';
 import { HuggingFaceSemanticEvidenceIngestService } from '../modules/v1-pilot/alpha/huggingface-semantic-evidence-ingest.service';
 import { LlmAlphaService } from '../modules/v1-pilot/alpha/llm-alpha.service';
 import { LlmEventFeatureService } from '../modules/v1-pilot/alpha/llm-event-feature.service';
@@ -162,6 +163,10 @@ export async function createLinceiRuntime(
   );
   const llmAlphaService = new LlmAlphaService(repo(AlphaDecision));
   const metaAlphaService = new MetaAlphaService(repo(AlphaDecision));
+  const currentAlphaTargetService = new CurrentAlphaTargetService(
+    repo(AlphaDecision),
+    repo(PortfolioTargetSnapshot),
+  );
   const leanLocalSimulatorService = new LeanLocalSimulatorService();
   const leanCliRunner = new LeanCliRunner();
   const leanRunImportService = new LeanRunImportService(
@@ -191,6 +196,7 @@ export async function createLinceiRuntime(
   const leanPaperBridgeService = new LeanPaperBridgeService(
     controlPlaneService,
     leanRunImportService,
+    currentAlphaTargetService,
     repo(PortfolioTargetSnapshot),
     repo(PaperOrderPlan),
   );
@@ -205,7 +211,7 @@ export async function createLinceiRuntime(
   );
   const liveShadowService = new LiveShadowService(
     leanRunImportService,
-    repo(PortfolioTargetSnapshot),
+    currentAlphaTargetService,
     repo(LiveShadowRecord),
   );
   const tossWriteBrokerAdapter = new TossWriteBrokerAdapter();

--- a/config/universes/quality-gated-v2.json
+++ b/config/universes/quality-gated-v2.json
@@ -19,10 +19,31 @@
     "software_cybersecurity": 0.3,
     "power_electrification": 0.3,
     "space_aerospace": 0.12,
+    "self_funded_etf_baseline": 1.0,
+    "defensive_fixed_income": 1.0,
     "cash_risk_off": 1.0,
     "benchmark": 1.0
   },
   "profiles": [
+    {
+      "name": "self_funded_etf_baseline",
+      "description": "Liquid ETF trend/defensive baseline for the first self-funded capital evidence slice.",
+      "activeSymbols": [
+        "SPY",
+        "QQQ",
+        "TLT",
+        "IEF"
+      ],
+      "benchmarkSymbols": [
+        "SPY",
+        "QQQ"
+      ],
+      "watchlistSymbols": [
+        "SGOV",
+        "IWM",
+        "XLU"
+      ]
+    },
     {
       "name": "quality_core_backtest_safe",
       "description": "Default backtest-safe quality universe. It excludes forward-only launches and daily leveraged ETFs.",
@@ -485,7 +506,7 @@
       "assetType": "etf",
       "status": "benchmark",
       "tier": "benchmark",
-      "sleeve": "benchmark",
+      "sleeve": "self_funded_etf_baseline",
       "maxPositionPct": 0.35,
       "rationale": "Broad market benchmark and legacy smoke-test symbol."
     },
@@ -495,9 +516,35 @@
       "assetType": "etf",
       "status": "benchmark",
       "tier": "benchmark",
-      "sleeve": "benchmark",
+      "sleeve": "self_funded_etf_baseline",
       "maxPositionPct": 0.35,
       "rationale": "Growth/technology benchmark and legacy smoke-test symbol."
+    },
+    {
+      "symbol": "TLT",
+      "name": "iShares 20+ Year Treasury Bond ETF",
+      "assetType": "etf",
+      "status": "benchmark",
+      "tier": "defensive_fixed_income",
+      "sleeve": "defensive_fixed_income",
+      "maxPositionPct": 0.35,
+      "rationale": "Long-duration Treasury ETF used for liquid defensive allocation and trend baseline testing.",
+      "sourceRefs": [
+        "https://www.ishares.com/us/products/239454/ishares-20-year-treasury-bond-etf"
+      ]
+    },
+    {
+      "symbol": "IEF",
+      "name": "iShares 7-10 Year Treasury Bond ETF",
+      "assetType": "etf",
+      "status": "benchmark",
+      "tier": "defensive_fixed_income",
+      "sleeve": "defensive_fixed_income",
+      "maxPositionPct": 0.35,
+      "rationale": "Intermediate-duration Treasury ETF used for defensive allocation and lower-volatility baseline testing.",
+      "sourceRefs": [
+        "https://www.ishares.com/us/products/239456/ishares-710-year-treasury-bond-etf"
+      ]
     },
     {
       "symbol": "IWM",

--- a/docs/capital-evidence-work-plan.md
+++ b/docs/capital-evidence-work-plan.md
@@ -1,0 +1,123 @@
+# Capital Evidence Work Plan
+
+Status: supporting implementation plan.
+
+This plan covers the next broker-excluded evidence slice. It does not approve broker writes, broker API integration, Darwinex/Zero implementation, leverage, derivatives, or capital-limit changes.
+
+## Objective
+
+Make the current capital evidence loop more reliable and more reviewable before any broker API integration:
+
+```text
+data -> alpha -> backtest -> QuantConnect Cloud import -> portfolio target -> risk -> paper/shadow -> reconciliation -> learning
+```
+
+## Current Blocker
+
+`capital status` reports the current milestone as blocked by broker-read-only and pre-trade risk check readiness. That is expected, but the broker-excluded loop still has three implementation gaps:
+
+- `capital run` can run long without step progress or a bounded blocked result.
+- The CLI does not have a triage command that turns the status tree into one next safe action.
+- The first self-funded baseline path still defaults toward the theme-stock universe instead of a liquid ETF trend/defensive universe.
+
+## Core Loop Impact
+
+This slice advances the loop before the broker boundary:
+
+- Data and alpha: use a liquid ETF baseline universe by default for `capital run`.
+- Backtest and Cloud import: keep local LEAN and QuantConnect Cloud steps explicit, bounded, and recorded as passed or blocked.
+- Paper/shadow/reconciliation/learning: keep single-writer execution-like stages unchanged.
+- Pre-trade risk check: continue to fail closed because broker-read-only evidence and broker-write approval are out of scope.
+
+## Scope
+
+In:
+
+- Add bounded step execution and progress events for `capital run`.
+- Add `capital triage` as a read-only operator command.
+- Add a liquid ETF baseline universe profile and make `capital run` default to `SPY,QQQ,TLT,IEF`.
+- Preserve passed, failed, blocked, and flat/no-order variant outcomes.
+
+Out:
+
+- Broker API integration.
+- Broker submit, cancel, replace, flatten, transfer, or margin/account mutation.
+- Darwinex/Zero adapter work.
+- Frontend/dashboard changes.
+- Broad framework rewrites.
+
+## Evidence Slice
+
+Hypothesis:
+
+- A liquid ETF trend/defensive baseline is the first self-funded capital baseline worth validating before theme-stock or LLM-heavy variants.
+
+Universe:
+
+- `SPY,QQQ,TLT,IEF`
+
+Variants:
+
+- `trend-regime-numeric-v1`
+- `semantic-llm-v1`
+- `trend-regime-combined-v1`
+
+Failure condition:
+
+- Any step that cannot finish within its configured timeout records a blocked step with the step key, timeout, and blocker reason.
+- Missing market data, missing QuantConnect credentials, missing Cloud artifacts, or broker-read-only blockers stay blocked instead of being filled by placeholder evidence.
+
+Direct commands:
+
+```bash
+bun --cwd=backend run lincei -- capital triage --json
+bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --step-timeout-ms 60000 --json
+```
+
+Expected artifacts:
+
+- `CapitalEvidenceSliceResult.steps[]` contains started/completed timestamps, status, blockers, and evidence refs for every attempted step.
+- `ResearchJobRecord` retains the numeric, LLM-derived, and combined ablation variant outcomes.
+- `capital triage` returns one recommended next action, exact blockers, and command text.
+
+## Acceptance Criteria
+
+Passed:
+
+- `capital triage --json` returns `status`, `recommendedAction`, and a concrete command.
+- `capital run --json` prints progress to stderr, returns JSON to stdout, and does not hang indefinitely on async steps.
+- Local LEAN backtest execution has a process timeout when invoked through this path.
+- Default `capital run` universe is `SPY,QQQ,TLT,IEF` unless explicitly overridden.
+
+Blocked:
+
+- Broker-read-only and broker-write readiness remain blocked until a separate approved broker-write spec exists.
+- QuantConnect Cloud credential gaps remain blocked evidence.
+
+Failed:
+
+- A code exception that is not a known policy blocker returns a failed or blocked step with the exact error message instead of silent progress loss.
+
+## Verification
+
+Direct execution:
+
+```bash
+bun --cwd=backend run lincei -- capital triage --json
+bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --step-timeout-ms 1000 --json
+```
+
+Focused tests:
+
+```bash
+cd backend
+bun run test -- src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts src/cli/lincei.spec.ts
+bun run build
+```
+
+## Non-Goals
+
+- No broker writes.
+- No broker API integration.
+- No simulator or placeholder evidence promoted as QuantConnect Cloud promotion evidence.
+- No LLM output crosses into broker credentials, raw broker order payloads, or final order quantities.

--- a/result.md
+++ b/result.md
@@ -8,15 +8,17 @@ Source of truth: [SPEC.md](SPEC.md), [terminology.md](terminology.md), and `docs
 
 ## 1. One-line Conclusion
 
-The project can now run data ingestion, alpha replay, QuantConnect Cloud backtest import, portfolio target import, historical paper replay, shadow recording, learning, and pre-trade risk check through the `lincei` CLI.
+The project now has a working current-market paper evidence path:
 
-It is still **not ready to trade real money** because the current paper cycle, Toss read-only reconciliation, broker-write flags, and broker credentials are intentionally missing or blocked.
+`fresh alpha decisions -> current portfolio target -> current paper plan -> reconciliation -> current shadow record -> promotion decision -> pre-trade risk check`
+
+It is still **not ready to trade real money** because broker read-only reconciliation, Toss credentials, broker-write readiness flags, and the future broker-write spec are still blocked or missing.
 
 ## 2. Current Flow
 
 ```mermaid
 flowchart TD
-    A["Research corpus<br/>Alpha Architect hypotheses"] --> B["Point-in-time data<br/>Stooq market bars + text evidence"]
+    A["Research corpus<br/>Alpha Architect hypotheses"] --> B["Point-in-time data<br/>Stooq bars + text evidence"]
     B --> C["Feature snapshots"]
     C --> D["Numeric alpha decisions"]
     B --> E["LLM-derived features"]
@@ -24,52 +26,72 @@ flowchart TD
     D --> G["Combined/meta alpha decisions"]
     F --> G
     G --> H["Variant evidence<br/>numeric / LLM / combined"]
-    H --> I["QuantConnect Cloud backtest import"]
-    I --> J["Portfolio targets<br/>normalized target weights"]
-    J --> K["Historical paper replay"]
-    J --> L["Historical shadow record"]
-    K --> M["Reconciliation"]
+    H --> I["QuantConnect Cloud backtest import<br/>validation evidence"]
+    I --> J["Current alpha target<br/>fresh paper candidate"]
+    J --> K["Current paper cycle"]
+    J --> L["Current shadow record"]
+    K --> M["Paper reconciliation"]
     L --> N["Learning / promotion decision"]
     M --> O["Pre-trade risk check"]
     N --> O
     O --> P["Real broker write<br/>blocked by design"]
 ```
 
-Important boundary: the LLM participates before the backtest by producing typed semantic features and LLM alpha decisions. It does not receive broker credentials, does not create raw broker orders, and does not decide final broker quantities.
+Important boundary: the LLM participates before backtesting through typed semantic features and LLM alpha decisions. It does not receive broker credentials, does not create raw broker orders, and does not decide final broker quantities.
 
-## 3. What Is Working Now
+## 3. What Works Now
 
 | Area | Current result |
 | --- | --- |
 | Stooq market data | `STOOQ_API_KEY` is configured locally; market ingestion can pass. |
-| Alpha replay | `alpha run` can be repeated without duplicate key crashes. Feature snapshots, LLM event features, and alpha decisions are upserted idempotently. |
-| Variant evidence | Numeric / LLM / combined variants are recorded, including passed, failed, blocked, and flat/no-order outcomes. |
-| QuantConnect Cloud | REST credentials work. Project `32097697` and backtest `ecd033aae81ec9f98e1c24b4c5a58d4c` were imported. |
-| Cloud strategy evidence | Imported run `qc-import-ecd033aae81e` is `passed`, runtime `quantconnect-cloud`, promotion eligible as backtest evidence. |
-| Portfolio target import | Cloud portfolio target snapshot is persisted to SQLite. Current target count is 22. |
-| Target normalization | Cloud symbol suffixes like `NVDA RHM8UTD8DT2D` are normalized to broker-facing tickers like `NVDA`. Sell fills no longer double-flip sign. |
-| Paper replay | Historical paper replay plan `3` is `reconciled` with matched reconciliation and 2 fills. |
-| Shadow record | Historical target shadow record exists and reconciles as matched. |
-| Pre-trade risk check | Runs fail-closed and reports concrete blockers. |
+| Alpha replay | Alpha feature and decision ledgers are idempotent. |
+| QuantConnect Cloud | Project `32097697` and backtest `ecd033aae81ec9f98e1c24b4c5a58d4c` imported as `qc-import-ecd033aae81e`. |
+| Cloud strategy evidence | Cloud run is `passed`, runtime `quantconnect-cloud`, promotion eligible as validation evidence. |
+| Cloud target import | Historical Cloud target normalization is fixed. Previous false gross exposure around 48x is now corrected. |
+| Current target generation | Latest validated alpha mode is `numeric-only`; current target snapshot is generated from fresh numeric alpha decisions. |
+| Current paper cycle | Plan `4` is `reconciled` and `matched`. |
+| Current shadow record | `live-shadow-20260529005300` recorded as `current_live_shadow`. |
+| Promotion decision | Latest learning run accepted promotion evidence. |
+| Pre-trade risk check | Runs fail-closed and now blocks only on broker-readiness items, not paper/current-shadow evidence. |
 
-Latest important target numbers:
+Latest current target:
 
-| Metric | Value | Meaning |
-| --- | --- | --- |
-| `targetCount` | 22 | Number of imported target rows. |
-| `grossExposurePct` | 0.257951 | Stored as target-weight fraction, about 25.8% gross target exposure. |
-| `maxSingleNamePct` | 0.062675 | Stored as target-weight fraction, about 6.3% max single-name target. |
+| Field | Value |
+| --- | --- |
+| target id | `current-alpha-target-qc-import-ecd033aae81e-numeric-5e360d0d3d5f` |
+| source | current numeric alpha decisions linked to Cloud validation run |
+| target count | 2 |
+| gross exposure | `0.2` target-weight fraction, about 20% |
+| max single-name | `0.1` target-weight fraction, about 10% |
+| symbols | `AMD`, `MRVL` |
 
-This fixed a serious earlier issue: Cloud targets were previously derived as roughly 48x gross exposure because sell fills were counted with the wrong sign.
+Latest current paper cycle:
+
+| Field | Value |
+| --- | --- |
+| plan id | `4` |
+| status | `reconciled` |
+| reconciliation | `matched` |
+| orders | `AMD` buy $1000, `MRVL` buy $1000 |
+| broker write | disabled |
+
+Latest promotion decision:
+
+| Field | Value |
+| --- | --- |
+| id | `promotion-20260529005329` |
+| status | `accepted` |
+| current live shadow | true |
+| cloud runtime | true |
+| selected-run-bias check | passed |
 
 ## 4. What Is Still Blocked
 
 | Area | Status | Why it matters |
 | --- | --- | --- |
-| Current paper cycle | `missing` | Historical replay exists, but live preflight requires current paper trading evidence for the latest target. |
-| Current shadow evidence | `blocked for promotion` | Latest shadow record is `historical_target_replay`; promotion requires `current_live_shadow`. |
 | Broker read-only | `blocked` | Current broker snapshot is `simulated`, not a matched Toss read-only poll. |
-| Broker credentials | `missing` | Toss credential env is not configured. |
+| Broker credentials | `missing` | Toss credential env or external secret ref is not configured. |
+| Broker snapshot reconciliation | `blocked` | Snapshot reconciliation is `not_checked`; matched required before live. |
 | Broker-write flags | `not ready` | `brokerWriteEnabled`, `liveTradingEnabled`, schema verification, cancel/flatten, and open-order polling flags remain false. |
 | Real broker writes | `deferred` | Requires a separate user-approved broker-write implementation spec. |
 | Darwinex/Zero | `deferred` | Should wait until self-funded capital evidence and track record are stronger. |
@@ -79,61 +101,37 @@ Latest preflight blocker summary:
 ```text
 status: blocked
 main blockers:
-- Only historical paper replay exists for the latest LEAN target.
-- Toss read-only broker snapshot is missing.
-- Broker snapshot reconciliation is not matched.
-- Broker credentials are missing.
-- Broker-write/live-trading/schema/cancel/open-order flags are not ready.
+- latest broker snapshot is simulated, not Toss read-only
+- broker snapshot reconciliation is not matched
+- broker credentials are missing
+- broker-write/live-trading/schema/cancel/open-order flags are not ready
 ```
 
-## 5. Why Current Paper Is Still Missing
-
-There are two paper modes:
-
-| Mode | Meaning | Current state |
-| --- | --- | --- |
-| Historical paper replay | Replays imported historical backtest targets through the paper ledger to prove plumbing and reconciliation. | Working: plan `3`, matched. |
-| Current paper cycle | Uses current-market target evidence and is allowed to count toward live preflight. | Still blocked. |
-
-The current paper run correctly refuses to treat historical Cloud backtest targets as current-market readiness:
-
-```text
-Paper risk evaluation DENY:
-- Market data is stale for the active policy.
-- Paper execution requires human approval.
-- Human approval is required outside dry-run mode.
-```
-
-This is the right safety behavior. It means the next core implementation should not be another dashboard. It should create a clean current-market paper cycle path.
-
-## 6. Next Work, In Order
+## 5. Next Work, In Order
 
 | Priority | Work | Direct proof |
 | --- | --- | --- |
-| P0 | Build a current-market paper cycle path from fresh alpha decisions and normalized long-only target candidates. Historical Cloud backtest targets must remain replay evidence only. | `bun --cwd=backend run lincei -- paper run --json` returns a reconciled current paper plan. |
-| P1 | Add explicit operator approval or dry-run approval handling for current paper execution without enabling real broker writes. | Paper run records approval custody and stays broker-write disabled. |
-| P2 | Implement Toss read-only account/open-order polling and reconciliation. No write calls. | `preflight run` no longer says broker snapshot is simulated or stale. |
-| P3 | Keep QuantConnect Cloud import as promotion-quality backtest evidence, but separate it from current-market target generation. | Status shows Cloud evidence and current paper evidence separately. |
-| P4 | Re-run learning and promotion after current paper + current shadow exist. | Promotion blocker moves from `historical_target_replay` to any remaining real blocker. |
-| P5 | Only after the above, draft the broker-write spec for user approval. | No implementation before explicit approval. |
+| P0 | Implement Toss read-only account, position, cash, and open-order polling without any write calls. | `preflight run` no longer says broker snapshot is simulated or stale. |
+| P1 | Reconcile Toss read-only snapshot against local broker/account state. | Broker snapshot reconciliation becomes `matched`. |
+| P2 | Add explicit external secret handling for Toss credentials. | `credentialMode` becomes `external-secret`, not `missing` or `local-dev-env`. |
+| P3 | Keep broker-write flags false until a separate broker-write spec is approved. | Preflight remains blocked only by intentionally false write flags. |
+| P4 | Draft broker-write spec for user approval after read-only reconciliation is proven. | No submit/cancel/replace/flatten implementation before approval. |
 
-## 7. Commands Used For Review
+## 6. Commands Used For Review
 
 ```bash
-bun --cwd=backend run lincei -- qc import-backtest --project-id 32097697 --backtest-id ecd033aae81ec9f98e1c24b4c5a58d4c --json
-bun --cwd=backend run lincei -- paper replay --json
+bun --cwd=backend run lincei -- paper run --json
 bun --cwd=backend run lincei -- shadow run --json
 bun --cwd=backend run lincei -- learning run --json
 bun --cwd=backend run lincei -- preflight run --json
 bun --cwd=backend run lincei -- capital status --json
 ```
 
-Validation run:
+Focused validation:
 
 ```bash
 cd backend
-bun run test -- src/runtime/create-lincei-runtime.spec.ts src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts src/modules/v1-pilot/lean/lean-cloud-artifact-mapper.spec.ts src/modules/v1-pilot/lean/lean-run-acceptance.spec.ts src/modules/v1-pilot/lean/lean-run-import.service.spec.ts src/modules/v1-pilot/lean/lean-cloud.runner.spec.ts src/modules/v1-pilot/paper/lean-paper-bridge.service.spec.ts src/modules/v1-pilot/v1-pilot-status-stage.builder.spec.ts
-bun run build
+bun run test -- src/modules/v1-pilot/alpha/current-alpha-target.service.spec.ts src/modules/v1-pilot/paper/lean-paper-bridge.service.spec.ts src/modules/v1-pilot/live/live-preflight.service.spec.ts src/runtime/create-lincei-runtime.spec.ts
 ```
 
-Result: 8 focused suites / 26 tests passed, backend build passed.
+Result: 4 focused suites / 9 tests passed.

--- a/result.md
+++ b/result.md
@@ -1,137 +1,305 @@
-# Lincei Quant Research Engine: Current Capital Evidence Status
+# Lincei Quant Research Engine: Project Map And Current Status
 
 Status: supporting review note.
 
-Last checked: 2026-05-29 on `Darwin arm64`.
+Last checked: 2026-06-01 on `Darwin arm64`, Bun `1.3.5`.
 
-Source of truth: [SPEC.md](SPEC.md), [terminology.md](terminology.md), and `docs/spec/`. This file explains the current implementation state in plain language. It is not the normative spec.
+Source of truth: [SPEC.md](SPEC.md), [terminology.md](terminology.md), and `docs/spec/`. This file is a plain-language guide for review. It is not the normative spec.
 
-## 1. One-line Conclusion
+## 1. What This Project Is
 
-The project now has a working current-market paper evidence path:
+This project is trying to build a self-funded capital allocation system:
 
-`fresh alpha decisions -> current portfolio target -> current paper plan -> reconciliation -> current shadow record -> promotion decision -> pre-trade risk check`
+1. collect market and text data,
+2. turn that data into features,
+3. produce alpha decisions,
+4. validate those decisions with LEAN and QuantConnect Cloud artifacts,
+5. convert validated decisions into portfolio targets,
+6. rehearse execution through paper trading and shadow trading,
+7. reconcile intended state against observed state,
+8. block before real broker writes until a separate broker-write spec and real broker integration exist.
 
-It is still **not ready to trade real money** because broker read-only reconciliation, Toss credentials, broker-write readiness flags, and the future broker-write spec are still blocked or missing.
+The business goal is still real profit from the operator's own pre-funded capital first. Darwinex/Zero is a later track-record and performance-fee path, not the first implementation priority.
 
-## 2. Current Flow
+Important current boundary: the system does **not** submit real broker orders yet. It can produce and validate portfolio targets, but the pre-trade risk check intentionally blocks because real broker read-only snapshots, credentials, and broker-write approval are not in place.
+
+## 2. Whole-Project Flow
+
+```mermaid
+flowchart LR
+    subgraph P["Parallel research pipeline"]
+        direction TB
+        R["Strategy research corpus<br/>articles, papers, notes"]
+        H["Hypothesis registry<br/>testable strategy claims"]
+        D["Point-in-time data<br/>market bars, text evidence, availability time"]
+        F["Feature generation<br/>numeric features and LLM-derived features"]
+        A["Alpha decisions<br/>numeric, LLM-derived, combined"]
+        V["Variant records<br/>passed, failed, blocked, flat/no-order"]
+    end
+
+    subgraph Q["Validation"]
+        direction TB
+        L["Local LEAN validation<br/>simulator and artifact plumbing"]
+        C["QuantConnect Cloud import<br/>promotion-grade backtest artifacts"]
+        B["Bias checks<br/>multiple-testing and selected-run controls"]
+    end
+
+    subgraph S["Single-writer capital gate"]
+        direction TB
+        T["Portfolio target<br/>symbol weights and exposure"]
+        RISK["Pre-trade risk policy<br/>deterministic caps and blockers"]
+        PAPER["Paper trading<br/>simulated order plan"]
+        SHADOW["Shadow trading<br/>live-data decision record, no broker write"]
+        RECON["Reconciliation<br/>intended versus observed state"]
+        LEARN["Learning / promotion ledger<br/>accepted or blocked"]
+    end
+
+    subgraph X["Blocked broker boundary"]
+        direction TB
+        SNAP["Broker read-only snapshot<br/>real account, cash, positions, open orders"]
+        CHECK["Pre-trade risk check<br/>fail closed"]
+        WRITE["Broker-write path<br/>submit, cancel, replace, flatten"]
+    end
+
+    R --> H --> D --> F --> A --> V
+    V --> L --> C --> B
+    B --> T --> RISK
+    RISK --> PAPER --> RECON
+    RISK --> SHADOW --> LEARN
+    RECON --> LEARN --> SNAP --> CHECK --> WRITE
+
+    classDef ready fill:#eaf7ee,stroke:#2e7d32,color:#16351f
+    classDef blocked fill:#fff1f0,stroke:#c62828,color:#4b1111
+    class R,H,D,F,A,V,L,C,B,T,RISK,PAPER,SHADOW,RECON,LEARN ready
+    class SNAP,CHECK,WRITE blocked
+```
+
+Read this as two halves:
+
+- Before promotion, many jobs can run in parallel: data ingestion, feature generation, LLM-derived feature extraction, ablations, and backtest sweeps.
+- After promotion, portfolio target consolidation, risk, paper trading, shadow trading, reconciliation, and broker checks must be single-writer and fail closed.
+
+## 3. What `capital run` Now Does
+
+The current main operator command is:
+
+```bash
+bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --step-timeout-ms 60000 --json
+```
+
+It is a broker-excluded vertical slice. It refreshes everything that can be proven before broker API integration.
 
 ```mermaid
 flowchart TD
-    A["Research corpus<br/>Alpha Architect hypotheses"] --> B["Point-in-time data<br/>Stooq bars + text evidence"]
-    B --> C["Feature snapshots"]
-    C --> D["Numeric alpha decisions"]
-    B --> E["LLM-derived features"]
-    E --> F["LLM alpha decisions"]
-    D --> G["Combined/meta alpha decisions"]
-    F --> G
-    G --> H["Variant evidence<br/>numeric / LLM / combined"]
-    H --> I["QuantConnect Cloud backtest import<br/>validation evidence"]
-    I --> J["Current alpha target<br/>fresh paper candidate"]
-    J --> K["Current paper cycle"]
-    J --> L["Current shadow record"]
-    K --> M["Paper reconciliation"]
-    L --> N["Learning / promotion decision"]
-    M --> O["Pre-trade risk check"]
-    N --> O
-    O --> P["Real broker write<br/>blocked by design"]
+    START["CLI input<br/>hypothesis, universe, timeout, worker count"] --> CORPUS["Research corpus ingest"]
+    CORPUS --> TEXT["Point-in-time text evidence ingest<br/>FOMC text evidence"]
+    TEXT --> DATA["Point-in-time market data<br/>Stooq bars and LEAN local data"]
+    DATA --> ALPHA["Alpha cycle<br/>feature snapshots and alpha decisions"]
+
+    ALPHA --> NUM["Variant: trend-regime-numeric-v1<br/>numeric alpha"]
+    ALPHA --> LLM["Variant: semantic-llm-v1<br/>LLM-derived alpha signal"]
+    ALPHA --> COMBO["Variant: trend-regime-combined-v1<br/>numeric plus LLM-derived features"]
+
+    NUM --> VARIANTS["Retained variant outcomes<br/>passed / failed / blocked / flat/no-order"]
+    LLM --> VARIANTS
+    COMBO --> VARIANTS
+
+    VARIANTS --> LEAN["Local LEAN validation attempt<br/>bounded by timeout"]
+    LEAN --> QC["QuantConnect Cloud credential and project check"]
+    QC --> BIAS["Multiple-testing bias check<br/>keeps losing and blocked variants"]
+    BIAS --> PAPER["Current paper trading cycle"]
+    PAPER --> SHADOW["Current shadow trading record"]
+    SHADOW --> LEARNING["Learning / promotion decision"]
+    LEARNING --> PREFLIGHT["Pre-trade risk check<br/>blocked at broker boundary"]
+
+    classDef input fill:#eef5ff,stroke:#1565c0,color:#0b2b4f
+    classDef pass fill:#eaf7ee,stroke:#2e7d32,color:#16351f
+    classDef block fill:#fff1f0,stroke:#c62828,color:#4b1111
+    class START input
+    class CORPUS,TEXT,DATA,ALPHA,NUM,LLM,COMBO,VARIANTS,LEAN,QC,BIAS,PAPER,SHADOW,LEARNING pass
+    class PREFLIGHT block
 ```
 
-Important boundary: the LLM participates before backtesting through typed semantic features and LLM alpha decisions. It does not receive broker credentials, does not create raw broker orders, and does not decide final broker quantities.
+New implementation details reflected in this flow:
 
-## 3. What Works Now
-
-| Area | Current result |
+| Area | Current behavior |
 | --- | --- |
-| Stooq market data | `STOOQ_API_KEY` is configured locally; market ingestion can pass. |
-| Alpha replay | Alpha feature and decision ledgers are idempotent. |
-| QuantConnect Cloud | Project `32097697` and backtest `ecd033aae81ec9f98e1c24b4c5a58d4c` imported as `qc-import-ecd033aae81e`. |
-| Cloud strategy evidence | Cloud run is `passed`, runtime `quantconnect-cloud`, promotion eligible as validation evidence. |
-| Cloud target import | Historical Cloud target normalization is fixed. Previous false gross exposure around 48x is now corrected. |
-| Current target generation | Latest validated alpha mode is `numeric-only`; current target snapshot is generated from fresh numeric alpha decisions. |
-| Current paper cycle | Plan `4` is `reconciled` and `matched`. |
-| Current shadow record | `live-shadow-20260529005300` recorded as `current_live_shadow`. |
-| Promotion decision | Latest learning run accepted promotion evidence. |
-| Pre-trade risk check | Runs fail-closed and now blocks only on broker-readiness items, not paper/current-shadow evidence. |
+| Default universe | `SPY, QQQ, TLT, IEF`, a liquid ETF trend/defensive baseline. |
+| Step timeout | Each major `capital run` step can return a bounded `blocked` result instead of hanging indefinitely. |
+| Progress events | `capital run --json` prints machine-readable final JSON to stdout and progress/logging to stderr. |
+| Variant retention | Passed, failed, blocked, and flat/no-order variants are retained to reduce multiple-testing bias. |
+| LEAN timeout | `lean full-backtest` now accepts `--backtest-timeout-ms`; timeouts become explicit blockers. |
+| Triage | `capital triage --json` returns one safe next action instead of forcing manual status interpretation. |
 
-Latest current target:
+## 4. Decision Objects In Plain Language
 
-| Field | Value |
-| --- | --- |
-| target id | `current-alpha-target-qc-import-ecd033aae81e-numeric-5e360d0d3d5f` |
-| source | current numeric alpha decisions linked to Cloud validation run |
-| target count | 2 |
-| gross exposure | `0.2` target-weight fraction, about 20% |
-| max single-name | `0.1` target-weight fraction, about 10% |
-| symbols | `AMD`, `MRVL` |
+The project does not jump from "LLM says buy" to "broker order." It passes through typed objects.
 
-Latest current paper cycle:
+```mermaid
+flowchart LR
+    I["Input records<br/>SPY bar, FOMC statement, research note"] --> FS["Feature snapshot<br/>trend, volatility, regime, semantic fields"]
+    FS --> AD["AlphaDecision<br/>symbol, direction, horizon, confidence, expected return"]
+    AD --> INS["LEAN Insight<br/>forecast object inside LEAN"]
+    INS --> PT["Portfolio target<br/>target weight and exposure"]
+    PT --> INTENT["Execution intent<br/>paper/shadow only today"]
+    INTENT --> REC["Reconciliation<br/>matched or blocked"]
+    REC --> GATE["Pre-trade risk check<br/>unknown means blocked"]
+    GATE --> ORDER["Future broker order<br/>not implemented"]
 
-| Field | Value |
-| --- | --- |
-| plan id | `4` |
-| status | `reconciled` |
-| reconciliation | `matched` |
-| orders | `AMD` buy $1000, `MRVL` buy $1000 |
-| broker write | disabled |
-
-Latest promotion decision:
-
-| Field | Value |
-| --- | --- |
-| id | `promotion-20260529005329` |
-| status | `accepted` |
-| current live shadow | true |
-| cloud runtime | true |
-| selected-run-bias check | passed |
-
-## 4. What Is Still Blocked
-
-| Area | Status | Why it matters |
-| --- | --- | --- |
-| Broker read-only | `blocked` | Current broker snapshot is `simulated`, not a matched Toss read-only poll. |
-| Broker credentials | `missing` | Toss credential env or external secret ref is not configured. |
-| Broker snapshot reconciliation | `blocked` | Snapshot reconciliation is `not_checked`; matched required before live. |
-| Broker-write flags | `not ready` | `brokerWriteEnabled`, `liveTradingEnabled`, schema verification, cancel/flatten, and open-order polling flags remain false. |
-| Real broker writes | `deferred` | Requires a separate user-approved broker-write implementation spec. |
-| Darwinex/Zero | `deferred` | Should wait until self-funded capital evidence and track record are stronger. |
-
-Latest preflight blocker summary:
-
-```text
-status: blocked
-main blockers:
-- latest broker snapshot is simulated, not Toss read-only
-- broker snapshot reconciliation is not matched
-- broker credentials are missing
-- broker-write/live-trading/schema/cancel/open-order flags are not ready
+    classDef current fill:#eaf7ee,stroke:#2e7d32,color:#16351f
+    classDef future fill:#fff8e1,stroke:#f9a825,color:#4d3500
+    classDef blocked fill:#fff1f0,stroke:#c62828,color:#4b1111
+    class I,FS,AD,INS,PT,INTENT,REC current
+    class GATE blocked
+    class ORDER future
 ```
 
-## 5. Next Work, In Order
+Key terms:
 
-| Priority | Work | Direct proof |
-| --- | --- | --- |
-| P0 | Implement Toss read-only account, position, cash, and open-order polling without any write calls. | `preflight run` no longer says broker snapshot is simulated or stale. |
-| P1 | Reconcile Toss read-only snapshot against local broker/account state. | Broker snapshot reconciliation becomes `matched`. |
-| P2 | Add explicit external secret handling for Toss credentials. | `credentialMode` becomes `external-secret`, not `missing` or `local-dev-env`. |
-| P3 | Keep broker-write flags false until a separate broker-write spec is approved. | Preflight remains blocked only by intentionally false write flags. |
-| P4 | Draft broker-write spec for user approval after read-only reconciliation is proven. | No submit/cancel/replace/flatten implementation before approval. |
+| Term | Meaning in this project |
+| --- | --- |
+| `alpha` | A return forecast or edge estimate. It is not a broker order. |
+| `feature` | An input available at decision time. |
+| `LLM-derived feature` | Structured data extracted by an LLM from allowed point-in-time inputs. |
+| `AlphaDecision` | A typed forecast record: direction, confidence, horizon, expected return, and refs. |
+| `Portfolio target` | The intended exposure after portfolio construction and risk policy. |
+| `paper trading` | Simulated execution with paper account semantics. |
+| `shadow trading` | Live-data decision recording without broker writes. |
+| `pre-trade risk check` | Deterministic gate before execution-like action; unknown state blocks. |
+| `broker-write path` | Future submit/cancel/replace/flatten path; still out of scope. |
 
-## 6. Commands Used For Review
+## 5. Where The LLM Is Allowed
+
+The LLM is inside the alpha research loop, not inside the broker-write boundary.
+
+```mermaid
+flowchart TD
+    RAW["Allowed point-in-time text<br/>research notes, filings, macro statements"] --> LLM["LLM extraction job"]
+    LLM --> SF["LLM-derived feature<br/>typed fields with source refs"]
+    SF --> AS["LLM-derived alpha signal<br/>ablation variant"]
+    SF --> COMBO["Combined alpha signal<br/>numeric plus LLM-derived features"]
+    AS --> VALID["Backtest and Cloud validation"]
+    COMBO --> VALID
+    VALID --> TARGET["Portfolio target candidate"]
+    TARGET --> POLICY["Risk policy and paper/shadow execution intent"]
+
+    SECRET["Broker credentials"] -. "never sent" .-> LLM
+    ORDER["Raw broker order payload"] -. "never produced by LLM" .-> LLM
+    SIZE["Final broker quantity"] -. "not decided by LLM" .-> LLM
+
+    classDef allowed fill:#eaf7ee,stroke:#2e7d32,color:#16351f
+    classDef denied fill:#fff1f0,stroke:#c62828,color:#4b1111
+    class RAW,LLM,SF,AS,COMBO,VALID,TARGET,POLICY allowed
+    class SECRET,ORDER,SIZE denied
+```
+
+This is why `semantic-llm-v1` exists as a variant: it is tested against numeric and combined variants. It does not receive account credentials and it does not bypass portfolio or risk controls.
+
+## 6. Current Status From `capital triage`
+
+Latest command:
 
 ```bash
-bun --cwd=backend run lincei -- paper run --json
-bun --cwd=backend run lincei -- shadow run --json
-bun --cwd=backend run lincei -- learning run --json
-bun --cwd=backend run lincei -- preflight run --json
-bun --cwd=backend run lincei -- capital status --json
+bun --cwd=backend run lincei -- capital triage --json
 ```
 
-Focused validation:
+Current milestone: `self-funded-capital-evidence`
+
+| Count | Value |
+| --- | ---: |
+| ready stages | 9 |
+| blocked stages | 2 |
+| missing stages | 0 |
+| deferred stages | 3 |
+
+```mermaid
+flowchart TD
+    READY["Ready stages<br/>9 current stages"] --> R1["Hypothesis registry<br/>40 hypotheses, 15 P1 candidates"]
+    READY --> R2["Variant records<br/>36 jobs, 2 passed, 34 failed or blocked"]
+    READY --> R3["Feature store<br/>79 feature snapshots"]
+    READY --> R4["Alpha decisions<br/>numeric 79, LLM 130, meta 45"]
+    READY --> R5["Backtest validation<br/>QuantConnect Cloud run passed"]
+    READY --> R6["QuantConnect Cloud import<br/>qc-import-ecd033aae81e"]
+    READY --> R7["Portfolio targets<br/>2 imported targets"]
+    READY --> R8["Paper trading<br/>plan 6, reconciled, matched"]
+    READY --> R9["Open orders<br/>0 open or mismatched records"]
+
+    BLOCKED["Blocked stages<br/>2 current stages"] --> B1["Broker read-only<br/>latest snapshot is simulated"]
+    BLOCKED --> B2["Pre-trade risk check<br/>legacy key: live_preflight"]
+
+    B1 --> WHY1["Needs real broker account, cash, positions, and open-order snapshot"]
+    B2 --> WHY2["Needs matched reconciliation, credentials, schema verification, and approved broker-write flags"]
+
+    classDef ready fill:#eaf7ee,stroke:#2e7d32,color:#16351f
+    classDef blocked fill:#fff1f0,stroke:#c62828,color:#4b1111
+    class READY,R1,R2,R3,R4,R5,R6,R7,R8,R9 ready
+    class BLOCKED,B1,B2,WHY1,WHY2 blocked
+```
+
+Recommended safe next action from triage:
+
+```bash
+bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --step-timeout-ms 60000 --json
+```
+
+Why this is the recommendation: the remaining blocker is broker-read-only or broker-write readiness, so the safe action is to keep refreshing non-broker promotion evidence, paper trading artifacts, shadow trading records, reconciliation, and learning artifacts.
+
+## 7. What Is Done Versus Not Done
+
+| Area | Status | Meaning |
+| --- | --- | --- |
+| Strategy research corpus | implemented | Research hypotheses can be registered and reused. |
+| Point-in-time market data | implemented | Stooq-backed data ingestion and LEAN local data preparation exist. |
+| LLM-derived features | implemented | LLM output is structured as features and alpha variants. |
+| Numeric / LLM / combined variants | implemented | Variants are retained even when failed, blocked, or flat/no-order. |
+| Local LEAN validation | implemented but operationally bounded | It can run or block with timeout; local LEAN is not Cloud promotion evidence by itself. |
+| QuantConnect Cloud import | implemented | Cloud project/backtest artifacts can be imported when credentials and ids exist. |
+| Portfolio target generation | implemented | Validated alpha can become target weights and exposure. |
+| Paper trading | implemented | Current paper plans can be created and reconciled. |
+| Shadow trading | implemented | Live-data decisions can be recorded without broker writes. |
+| Learning / promotion ledger | implemented | Promotion decisions can be accepted or blocked from artifacts. |
+| Capital triage CLI | implemented | One next safe operator action can be derived from status. |
+| Broker read-only integration | blocked | No matched real broker snapshot is available yet. |
+| Broker-write path | not implemented | Needs explicit user-approved broker-write spec before code. |
+| Darwinex/Zero | deferred | Should follow self-funded track record, not precede it. |
+
+## 8. How Money Eventually Enters The Loop
+
+```mermaid
+flowchart LR
+    NOW["Current repo state<br/>broker-excluded evidence loop"] --> READONLY["Next required broker step<br/>read-only account snapshot"]
+    READONLY --> MATCH["Reconciliation<br/>broker snapshot matches local intended state"]
+    MATCH --> SPEC["User-approved broker-write spec<br/>submit/cancel/replace/flatten rules"]
+    SPEC --> SMALLCAP["Self-funded capital allocation<br/>pre-funded operator capital"]
+    SMALLCAP --> TRACK["Real track record<br/>after-cost returns and drawdowns"]
+    TRACK --> DARWIN["Darwinex/Zero path<br/>later performance-fee opportunity"]
+
+    classDef now fill:#eaf7ee,stroke:#2e7d32,color:#16351f
+    classDef blocked fill:#fff1f0,stroke:#c62828,color:#4b1111
+    classDef future fill:#fff8e1,stroke:#f9a825,color:#4d3500
+    class NOW now
+    class READONLY,MATCH,SPEC blocked
+    class SMALLCAP,TRACK,DARWIN future
+```
+
+The next real-money blocker is not "the strategy cannot think." The current blocker is that the system cannot yet prove real broker account state, reconcile it, or submit/cancel/replace/flatten orders under an approved broker-write spec.
+
+## 9. Review Commands
+
+Use these commands to inspect the current state:
+
+```bash
+bun --cwd=backend run lincei -- capital triage --json
+bun --cwd=backend run lincei -- capital status --json
+bun --cwd=backend run lincei -- capital run --max-backtest-workers 1 --step-timeout-ms 60000 --json
+```
+
+Focused validation for the latest implementation:
 
 ```bash
 cd backend
-bun run test -- src/modules/v1-pilot/alpha/current-alpha-target.service.spec.ts src/modules/v1-pilot/paper/lean-paper-bridge.service.spec.ts src/modules/v1-pilot/live/live-preflight.service.spec.ts src/runtime/create-lincei-runtime.spec.ts
+bun run test -- src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts src/cli/lincei.spec.ts src/cli/capital-triage.spec.ts src/modules/v1-pilot/lean/lean-cli.runner.spec.ts
+bun run build
 ```
 
-Result: 4 focused suites / 9 tests passed.
+Latest direct status check used for this document: `capital triage --json` returned `blocked` with one recommended safe action and exact broker-boundary blockers.


### PR DESCRIPTION
## Summary
- Add a capital triage command that returns one safe broker-excluded next action.
- Bound capital evidence and LEAN validation steps with timeout blockers and progress events.
- Refresh the ETF baseline universe and project review diagrams.

## Validation
- git diff --check
- bun run test -- src/modules/v1-pilot/research/capital-evidence-slice.service.spec.ts src/cli/lincei.spec.ts src/cli/capital-triage.spec.ts src/modules/v1-pilot/lean/lean-cli.runner.spec.ts
- bun run build